### PR TITLE
Auto-apply self-update on Windows instead of manual instruction

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 )
 
-const Version = "0.0.3"
+const Version = "0.0.4"
 
 const (
 	ansiReset  = "\x1b[0m"

--- a/src/selfupdate.go
+++ b/src/selfupdate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -171,9 +172,18 @@ func runSelfUpdate(currentVersion string) {
 		batchPath := filepath.Join(os.TempDir(), "skl-update.bat")
 		batchContent := fmt.Sprintf("@echo off\r\ntimeout /t 1 /nobreak > NUL\r\nmove /y \"%s\" \"%s\" > NUL\r\ndel \"%%~f0\"\r\n",
 			tmpPath, execPath)
-		os.WriteFile(batchPath, []byte(batchContent), 0644)
-		fmt.Printf("%sDownloaded %s to:%s %s\n", ansiText, latestVersion, ansiReset, tmpPath)
-		fmt.Printf("%sTo apply the update, run after exiting this process:%s\n", ansiDim, ansiReset)
-		fmt.Printf("  %s%s%s\n", ansiText, batchPath, ansiReset)
+		if err := os.WriteFile(batchPath, []byte(batchContent), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to write update script: %v\n", err)
+			os.Exit(1)
+		}
+		if err := exec.Command("cmd", "/c", "start", "/b", "", batchPath).Start(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to launch update script: %v\n", err)
+			fmt.Printf("%sTo apply the update manually, run:%s\n  %s%s%s\n",
+				ansiDim, ansiReset, ansiText, batchPath, ansiReset)
+			return
+		}
+		fmt.Printf("%sUpdated to %s successfully.%s\n", ansiText, latestVersion, ansiReset)
+		fmt.Printf("%sApplying update as this process exits...%s\n", ansiDim, ansiReset)
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
## Summary
Modified the Windows self-update process to automatically launch the update script instead of requiring users to manually run it after exiting the application.

## Key Changes
- Added `os/exec` import to enable command execution
- Wrapped `os.WriteFile()` call with error handling to gracefully handle script creation failures
- Replaced manual instruction output with automatic execution of the update batch script using `cmd /c start /b`
- Added fallback mechanism: if script launch fails, users are prompted with manual instructions
- Updated success messaging to indicate the update is being applied automatically
- Added `os.Exit(0)` after successful script launch to allow the batch file to replace the executable

## Implementation Details
- The update script is now launched asynchronously using `exec.Command().Start()` (non-blocking) rather than `Run()`, allowing the current process to exit cleanly before the batch file attempts to replace it
- Error handling distinguishes between script creation failures and script launch failures, providing appropriate user feedback in each case
- The batch file itself handles the timing (1-second delay) to ensure the process has fully exited before attempting the file replacement

https://claude.ai/code/session_018fZYg4wNwXMvYFVRY5NCch