### PR TITLE
Fix skill discovery to use correct SKILL.md file path

### DIFF
--- a/src/add.go
+++ b/src/add.go
@@ -542,7 +542,7 @@ func discoverSkillsInDir(dir string, fullDepth bool, skillFilter string) []*Skil
 	var skills []*Skill
 	seen := map[string]bool{}
 	for _, skillMd := range allFound {
-		s, err := parseSkillMd(skillMd, false)
+		s, err := parseSkillMd(filepath.Join(skillMd, "SKILL.md"), false)
 		if err != nil || s == nil {
 			continue
 		}

--- a/src/go.mod
+++ b/src/go.mod
@@ -9,13 +9,15 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.36.0
+require (
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	golang.org/x/sys v0.36.0
+)
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/src/main.go
+++ b/src/main.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 )
 
-const Version = "0.0.6"
+const Version = "0.0.7"
 
 const (
 	ansiReset  = "\x1b[0m"


### PR DESCRIPTION
## Summary
Fixed a bug in the skill discovery process where the skill markdown file path was not being constructed correctly, causing skill parsing to fail.

## Changes
- Updated `discoverSkillsInDir()` in `add.go` to properly construct the full path to the `SKILL.md` file by joining the skill directory with the filename using `filepath.Join()`
- Previously, the function was passing just the directory path to `parseSkillMd()`, which expected the complete file path

## Details
The skill discovery function iterates through found skill directories but was incorrectly passing only the directory path to the parser. This change ensures the full path to `SKILL.md` within each skill directory is passed, allowing the parser to correctly locate and read the skill definition files.

https://claude.ai/code/session_01VDV2T2fGSLSrBjdt2mZqwf