### PR TITLE
Add `mdm doctor` command for health diagnostics

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,100 @@
+# mdm doctor
+
+Check the health of installed skills and project markdown files.
+
+`mdm doctor` runs a series of local checks and prints a report grouped by category. It covers skill installation integrity, agent symlinks, and any markdown files large enough to strain agent context windows — including instruction files, skill content, and general project docs.
+
+## Checks performed
+
+### Skills
+
+For each skill recorded in the lock file:
+
+| Check | What it catches |
+|---|---|
+| Directory exists | Skill was deleted from disk after install |
+| SKILL.md present and valid | Missing file or frontmatter without `name`/`description` |
+| Symlinks resolve | Agent-specific links (e.g. `.claude/skills/my-skill`) point to a missing target |
+| Hash matches lock | Skill files were modified manually since install |
+| Markdown file sizes | `.md` files inside the skill directory are too large |
+
+### Instruction files
+
+Checks every known agent instruction file in the project root for size:
+`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`, `.clinerules`, `.roorules`, `GEMINI.md`, `.github/copilot-instructions.md`, and others.
+
+### Project markdown
+
+Walks the entire project tree and flags any other `.md` file that is too large. Skips directories already covered above and common noise directories (`.git`, `node_modules`, `vendor`, `dist`, `build`, `.next`, etc.). Stops after 10,000 filesystem entries to avoid hangs on very large repositories.
+
+### Size thresholds
+
+| Size | Severity |
+|---|---|
+| ≥ 20 KB | Warning — may strain agent context windows |
+| ≥ 100 KB | Error — likely too large for agent context windows |
+
+## Output
+
+```
+Project skills:
+
+  ✓ my-skill
+    .agents/skills/my-skill
+
+  ✗ broken-skill
+    ✗ skill directory not found on disk — run `mdm skills install` to restore
+
+  ▲ large-skill
+    ▲ SKILL.md is 45KB — may strain agent context windows
+
+Instruction files:
+
+  ▲ CLAUDE.md is 32KB — may strain agent context windows
+
+Project markdown:
+
+  ▲ docs/reference.md is 28KB — may strain agent context windows
+
+Doctor complete: 3 skill(s) checked, project markdown scanned, 1 error(s), 2 warning(s)
+```
+
+Each skill shows a `✓` (ok), `▲` (warning), or `✗` (error). The summary line always prints, even when no skills are installed, so you know the checks ran.
+
+## Commands
+
+```
+mdm doctor       Check project and global skills, plus all project markdown
+mdm doctor -g    Check global skills only (skips project markdown scan)
+mdm doctor -p    Check project skills and project markdown only
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--global, -g` | Check global skills only |
+| `--project, -p` | Check project skills and project markdown only |
+
+### Examples
+
+```bash
+# Full check — skills (both scopes) + all project markdown
+mdm doctor
+
+# Only check globally installed skills
+mdm doctor -g
+
+# Only check project skills and local markdown
+mdm doctor -p
+```
+
+## Common issues and fixes
+
+| Issue | Fix |
+|---|---|
+| Skill directory not found | Run `mdm skills install` to restore from the lock file |
+| Skill content modified | Run `mdm skills update` to sync back to the source version |
+| Broken symlink | Re-install the skill with `mdm skills add` |
+| Instruction file too large | Split content into smaller files or remove outdated sections |
+| Large project markdown | Trim the file or exclude it from agent context |

--- a/src/commands/doctor.go
+++ b/src/commands/doctor.go
@@ -18,7 +18,19 @@ import (
 const (
 	fileSizeWarnBytes  = 20 * 1024  // 20 KB — may strain context windows
 	fileSizeErrorBytes = 100 * 1024 // 100 KB — likely too large
+
+	// Maximum filesystem entries walked before the project-wide markdown
+	// scan gives up, to avoid hangs on very large repositories.
+	markdownWalkLimit = 10_000
 )
+
+// Directories always skipped by name during the project-wide markdown walk.
+var markdownSkipDirNames = map[string]bool{
+	".git": true, "node_modules": true, "vendor": true,
+	"dist": true, "build": true, ".next": true, ".nuxt": true,
+	"__pycache__": true, ".cache": true, "target": true,
+	"coverage": true, ".nyc_output": true, ".venv": true, "venv": true,
+}
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -53,8 +65,9 @@ Checks performed:
   • Missing skill directories or SKILL.md files
   • Broken symlinks in agent skill directories
   • Skills modified since install (hash mismatch)
-  • Markdown files large enough to strain agent context windows
-  • Oversized project instruction files (CLAUDE.md, AGENTS.md, etc.)
+  • Markdown files inside skill directories that are too large
+  • Oversized agent instruction files (CLAUDE.md, AGENTS.md, .cursorrules, etc.)
+  • All other .md files in the project that may strain agent context windows
 
 %sExamples:%s
   mdm skills doctor
@@ -97,6 +110,11 @@ func runDoctor(opts DoctorOptions) {
 		}
 	}
 
+	// Directories and files already covered by skill/instruction checks; the
+	// project-wide markdown walk skips these to avoid double-reporting.
+	skipDirs := map[string]bool{}
+	skipFiles := map[string]bool{}
+
 	if checkProject {
 		localLock := lock.ReadLocalLock(cwd)
 		canonicalBase := getCanonicalSkillsDir(false, cwd)
@@ -109,15 +127,30 @@ func runDoctor(opts DoctorOptions) {
 			diagnoseSkill(&r, "", false, cwd)
 			results = append(results, r)
 		}
+
+		// All agent skill directories
+		skipDirs[filepath.Clean(canonicalBase)] = true
+		for _, agentCfg := range agent.AllAgents {
+			if agentCfg == nil {
+				continue
+			}
+			skipDirs[filepath.Clean(filepath.Join(cwd, agentCfg.SkillsDir))] = true
+			if agentCfg.InstructionsFile != "" {
+				skipFiles[filepath.Clean(filepath.Join(cwd, agentCfg.InstructionsFile))] = true
+			}
+		}
 	}
 
-	// Instruction-file check is project-level only; skip if --global
 	var instrIssues []doctorIssue
+	var mdIssues []doctorIssue
+	var mdTruncated bool
+
 	if checkProject {
 		instrIssues = checkInstructionFiles(cwd)
+		mdIssues, mdTruncated = checkProjectMarkdown(cwd, skipDirs, skipFiles)
 	}
 
-	if len(results) == 0 && len(instrIssues) == 0 {
+	if len(results) == 0 && len(instrIssues) == 0 && len(mdIssues) == 0 {
 		fmt.Printf("%sNo skills found.%s\n", ansiDim, ansiReset)
 		return
 	}
@@ -129,7 +162,7 @@ func runDoctor(opts DoctorOptions) {
 		return results[i].Name < results[j].Name
 	})
 
-	printDoctorResults(results, instrIssues, cwd)
+	printDoctorResults(results, instrIssues, mdIssues, mdTruncated, cwd)
 }
 
 // ── Checks ─────────────────────────────────────────────────────────────────────
@@ -254,7 +287,8 @@ func checkLargeMarkdown(r *doctorResult) {
 }
 
 // checkInstructionFiles scans the project root for known agent instruction
-// files (CLAUDE.md, AGENTS.md, etc.) and flags oversized ones.
+// files (CLAUDE.md, AGENTS.md, .cursorrules, .github/copilot-instructions.md,
+// etc.) and flags oversized ones.
 func checkInstructionFiles(cwd string) []doctorIssue {
 	seen := map[string]bool{}
 	var issues []doctorIssue
@@ -295,9 +329,69 @@ func checkInstructionFiles(cwd string) []doctorIssue {
 	return issues
 }
 
+// checkProjectMarkdown walks the project tree and flags .md files that are
+// large enough to strain agent context windows. It skips directories and files
+// already covered by the skill and instruction-file checks, as well as common
+// build/dependency directories. The walk stops after markdownWalkLimit
+// filesystem entries to prevent hangs on very large repositories.
+func checkProjectMarkdown(cwd string, skipDirs map[string]bool, skipFiles map[string]bool) (issues []doctorIssue, truncated bool) {
+	walked := 0
+
+	_ = filepath.WalkDir(cwd, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if walked >= markdownWalkLimit {
+			truncated = true
+			return fs.SkipAll
+		}
+		walked++
+
+		if d.IsDir() {
+			if markdownSkipDirNames[d.Name()] || skipDirs[filepath.Clean(path)] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if skipFiles[filepath.Clean(path)] {
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		size := info.Size()
+		rel, _ := filepath.Rel(cwd, path)
+
+		switch {
+		case size >= fileSizeErrorBytes:
+			issues = append(issues, doctorIssue{
+				Level:   "error",
+				Message: fmt.Sprintf("%s is %s — likely too large for agent context windows", rel, formatFileSize(size)),
+			})
+		case size >= fileSizeWarnBytes:
+			issues = append(issues, doctorIssue{
+				Level:   "warn",
+				Message: fmt.Sprintf("%s is %s — may strain agent context windows", rel, formatFileSize(size)),
+			})
+		}
+		return nil
+	})
+
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].Message < issues[j].Message
+	})
+	return issues, truncated
+}
+
 // ── Output ─────────────────────────────────────────────────────────────────────
 
-func printDoctorResults(results []doctorResult, instrIssues []doctorIssue, cwd string) {
+func printDoctorResults(results []doctorResult, instrIssues, mdIssues []doctorIssue, mdTruncated bool, cwd string) {
 	fmt.Println()
 
 	byScope := map[string][]doctorResult{}
@@ -345,7 +439,7 @@ func printDoctorResults(results []doctorResult, instrIssues []doctorIssue, cwd s
 
 	// Instruction files section
 	if len(instrIssues) > 0 {
-		fmt.Printf("%sProject files:%s\n\n", ansiText, ansiReset)
+		fmt.Printf("%sInstruction files:%s\n\n", ansiText, ansiReset)
 		for _, issue := range instrIssues {
 			icon, color := doctorIssueIcon(issue.Level)
 			fmt.Printf("  %s%s%s %s%s%s\n", color, icon, ansiReset, ansiDim, issue.Message, ansiReset)
@@ -354,6 +448,25 @@ func printDoctorResults(results []doctorResult, instrIssues []doctorIssue, cwd s
 			} else {
 				totalWarnings++
 			}
+		}
+		fmt.Println()
+	}
+
+	// General project markdown section
+	if len(mdIssues) > 0 || mdTruncated {
+		fmt.Printf("%sProject markdown:%s\n\n", ansiText, ansiReset)
+		for _, issue := range mdIssues {
+			icon, color := doctorIssueIcon(issue.Level)
+			fmt.Printf("  %s%s%s %s%s%s\n", color, icon, ansiReset, ansiDim, issue.Message, ansiReset)
+			if issue.Level == "error" {
+				totalErrors++
+			} else {
+				totalWarnings++
+			}
+		}
+		if mdTruncated {
+			fmt.Printf("  %s▲%s %sscan stopped after %d entries — run from a subdirectory to check further%s\n",
+				ansiYellow, ansiReset, ansiDim, markdownWalkLimit, ansiReset)
 		}
 		fmt.Println()
 	}

--- a/src/commands/doctor.go
+++ b/src/commands/doctor.go
@@ -150,11 +150,6 @@ func runDoctor(opts DoctorOptions) {
 		mdIssues, mdTruncated = checkProjectMarkdown(cwd, skipDirs, skipFiles)
 	}
 
-	if len(results) == 0 && len(instrIssues) == 0 && len(mdIssues) == 0 {
-		fmt.Printf("%sNo skills found.%s\n", ansiDim, ansiReset)
-		return
-	}
-
 	sort.Slice(results, func(i, j int) bool {
 		if results[i].Scope != results[j].Scope {
 			return results[i].Scope < results[j].Scope
@@ -162,7 +157,7 @@ func runDoctor(opts DoctorOptions) {
 		return results[i].Name < results[j].Name
 	})
 
-	printDoctorResults(results, instrIssues, mdIssues, mdTruncated, cwd)
+	printDoctorResults(results, instrIssues, mdIssues, mdTruncated, checkProject, cwd)
 }
 
 // ── Checks ─────────────────────────────────────────────────────────────────────
@@ -391,7 +386,7 @@ func checkProjectMarkdown(cwd string, skipDirs map[string]bool, skipFiles map[st
 
 // ── Output ─────────────────────────────────────────────────────────────────────
 
-func printDoctorResults(results []doctorResult, instrIssues, mdIssues []doctorIssue, mdTruncated bool, cwd string) {
+func printDoctorResults(results []doctorResult, instrIssues, mdIssues []doctorIssue, mdTruncated, scannedProject bool, cwd string) {
 	fmt.Println()
 
 	byScope := map[string][]doctorResult{}
@@ -473,7 +468,14 @@ func printDoctorResults(results []doctorResult, instrIssues, mdIssues []doctorIs
 
 	// Summary
 	total := len(results)
-	fmt.Printf("%sDoctor complete:%s %d skill(s) checked", ansiText, ansiReset, total)
+	if total > 0 {
+		fmt.Printf("%sDoctor complete:%s %d skill(s) checked", ansiText, ansiReset, total)
+	} else {
+		fmt.Printf("%sDoctor complete:%s no skills installed", ansiText, ansiReset)
+	}
+	if scannedProject {
+		fmt.Printf(", project markdown scanned")
+	}
 	if totalErrors > 0 {
 		fmt.Printf(", %s%d error(s)%s", ansiRed, totalErrors, ansiReset)
 	}

--- a/src/commands/doctor.go
+++ b/src/commands/doctor.go
@@ -1,0 +1,400 @@
+package commands
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/agent"
+	"github.com/sethcarney/mdm/internal/lock"
+	"github.com/sethcarney/mdm/internal/skill"
+)
+
+const (
+	fileSizeWarnBytes  = 20 * 1024  // 20 KB — may strain context windows
+	fileSizeErrorBytes = 100 * 1024 // 100 KB — likely too large
+)
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+type DoctorOptions struct {
+	Global  bool
+	Project bool
+}
+
+type doctorIssue struct {
+	Level   string // "error" or "warn"
+	Message string
+}
+
+type doctorResult struct {
+	Name   string
+	Scope  string
+	Path   string
+	Issues []doctorIssue
+}
+
+// ── Command ────────────────────────────────────────────────────────────────────
+
+func buildDoctorCmd() *cobra.Command {
+	var opts DoctorOptions
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check the health of installed skills",
+		Long: fmt.Sprintf(`Check installed skills for installation and content issues.
+
+Checks performed:
+  • Missing skill directories or SKILL.md files
+  • Broken symlinks in agent skill directories
+  • Skills modified since install (hash mismatch)
+  • Markdown files large enough to strain agent context windows
+  • Oversized project instruction files (CLAUDE.md, AGENTS.md, etc.)
+
+%sExamples:%s
+  mdm skills doctor
+  mdm skills doctor -g
+  mdm skills doctor -p`, ansiBold, ansiReset),
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runDoctor(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVarP(&opts.Global, "global", "g", false, "Check global skills only")
+	f.BoolVarP(&opts.Project, "project", "p", false, "Check project skills only")
+
+	return cmd
+}
+
+// ── Run ────────────────────────────────────────────────────────────────────────
+
+func runDoctor(opts DoctorOptions) {
+	checkGlobal := opts.Global || (!opts.Global && !opts.Project)
+	checkProject := opts.Project || (!opts.Global && !opts.Project)
+
+	cwd, _ := os.Getwd()
+
+	var results []doctorResult
+
+	if checkGlobal {
+		globalLock := lock.ReadSkillLock()
+		canonicalBase := getCanonicalSkillsDir(true, cwd)
+		for skillName, entry := range globalLock.Skills {
+			r := doctorResult{
+				Name:  skillName,
+				Scope: "global",
+				Path:  filepath.Join(canonicalBase, sanitizeName(skillName)),
+			}
+			diagnoseSkill(&r, entry.SkillFolderHash, true, cwd)
+			results = append(results, r)
+		}
+	}
+
+	if checkProject {
+		localLock := lock.ReadLocalLock(cwd)
+		canonicalBase := getCanonicalSkillsDir(false, cwd)
+		for skillName := range localLock.Skills {
+			r := doctorResult{
+				Name:  skillName,
+				Scope: "project",
+				Path:  filepath.Join(canonicalBase, sanitizeName(skillName)),
+			}
+			diagnoseSkill(&r, "", false, cwd)
+			results = append(results, r)
+		}
+	}
+
+	// Instruction-file check is project-level only; skip if --global
+	var instrIssues []doctorIssue
+	if checkProject {
+		instrIssues = checkInstructionFiles(cwd)
+	}
+
+	if len(results) == 0 && len(instrIssues) == 0 {
+		fmt.Printf("%sNo skills found.%s\n", ansiDim, ansiReset)
+		return
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Scope != results[j].Scope {
+			return results[i].Scope < results[j].Scope
+		}
+		return results[i].Name < results[j].Name
+	})
+
+	printDoctorResults(results, instrIssues, cwd)
+}
+
+// ── Checks ─────────────────────────────────────────────────────────────────────
+
+func diagnoseSkill(r *doctorResult, storedHash string, global bool, cwd string) {
+	// 1. Skill directory must exist
+	if _, err := os.Stat(r.Path); os.IsNotExist(err) {
+		r.Issues = append(r.Issues, doctorIssue{
+			Level:   "error",
+			Message: "skill directory not found on disk — run `mdm skills install` to restore",
+		})
+		return
+	}
+
+	// 2. SKILL.md must exist and have valid frontmatter
+	skillMdPath := filepath.Join(r.Path, "SKILL.md")
+	if _, err := os.Stat(skillMdPath); os.IsNotExist(err) {
+		r.Issues = append(r.Issues, doctorIssue{
+			Level:   "error",
+			Message: "SKILL.md not found in skill directory",
+		})
+	} else {
+		sk, err := skill.ParseSkillMd(skillMdPath, true)
+		if err != nil || sk == nil {
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "warn",
+				Message: "SKILL.md is missing required name or description fields",
+			})
+		}
+	}
+
+	// 3. Symlinks in agent-specific directories must resolve
+	checkAgentLinks(r, global, cwd)
+
+	// 4. Skill content must match the installed hash (global skills only)
+	if storedHash != "" {
+		current, err := lock.ComputeSkillFolderHash(r.Path)
+		if err == nil && current != storedHash {
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "warn",
+				Message: "skill content differs from installed version — run `mdm skills update` to sync",
+			})
+		}
+	}
+
+	// 5. Markdown files must not be too large for agent context windows
+	checkLargeMarkdown(r)
+}
+
+// checkAgentLinks verifies that symlinks in non-universal agent directories
+// point to an existing target.
+func checkAgentLinks(r *doctorResult, global bool, cwd string) {
+	sName := sanitizeName(r.Name)
+	for agentName, agentCfg := range agent.AllAgents {
+		if agentCfg == nil || agent.IsUniversalAgent(agentName) {
+			continue
+		}
+		var agentBase string
+		if global {
+			if agentCfg.GlobalSkillsDir == "" {
+				continue
+			}
+			agentBase = agentCfg.GlobalSkillsDir
+		} else {
+			agentBase = filepath.Join(cwd, agentCfg.SkillsDir)
+		}
+		linkPath := filepath.Join(agentBase, sName)
+		info, err := os.Lstat(linkPath)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			continue // not present or not a symlink
+		}
+		target, err := os.Readlink(linkPath)
+		if err != nil {
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "error",
+				Message: fmt.Sprintf("broken symlink in %s directory", agentCfg.DisplayName),
+			})
+			continue
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(linkPath), target)
+		}
+		if _, err := os.Stat(target); os.IsNotExist(err) {
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "error",
+				Message: fmt.Sprintf("broken symlink in %s directory: target not found", agentCfg.DisplayName),
+			})
+		}
+	}
+}
+
+// checkLargeMarkdown walks the skill directory and flags .md files that are
+// large enough to threaten agent context windows.
+func checkLargeMarkdown(r *doctorResult) {
+	_ = filepath.WalkDir(r.Path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		size := info.Size()
+		rel, _ := filepath.Rel(r.Path, path)
+		switch {
+		case size >= fileSizeErrorBytes:
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "error",
+				Message: fmt.Sprintf("%s is %s — likely too large for agent context windows", rel, formatFileSize(size)),
+			})
+		case size >= fileSizeWarnBytes:
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "warn",
+				Message: fmt.Sprintf("%s is %s — may strain agent context windows", rel, formatFileSize(size)),
+			})
+		}
+		return nil
+	})
+}
+
+// checkInstructionFiles scans the project root for known agent instruction
+// files (CLAUDE.md, AGENTS.md, etc.) and flags oversized ones.
+func checkInstructionFiles(cwd string) []doctorIssue {
+	seen := map[string]bool{}
+	var issues []doctorIssue
+
+	for _, agentCfg := range agent.AllAgents {
+		if agentCfg == nil || agentCfg.InstructionsFile == "" {
+			continue
+		}
+		fname := agentCfg.InstructionsFile
+		if seen[fname] {
+			continue
+		}
+		seen[fname] = true
+
+		path := filepath.Join(cwd, fname)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		size := info.Size()
+		switch {
+		case size >= fileSizeErrorBytes:
+			issues = append(issues, doctorIssue{
+				Level:   "error",
+				Message: fmt.Sprintf("%s is %s — likely too large for agent context windows", fname, formatFileSize(size)),
+			})
+		case size >= fileSizeWarnBytes:
+			issues = append(issues, doctorIssue{
+				Level:   "warn",
+				Message: fmt.Sprintf("%s is %s — may strain agent context windows", fname, formatFileSize(size)),
+			})
+		}
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].Message < issues[j].Message
+	})
+	return issues
+}
+
+// ── Output ─────────────────────────────────────────────────────────────────────
+
+func printDoctorResults(results []doctorResult, instrIssues []doctorIssue, cwd string) {
+	fmt.Println()
+
+	byScope := map[string][]doctorResult{}
+	for _, r := range results {
+		byScope[r.Scope] = append(byScope[r.Scope], r)
+	}
+
+	totalErrors, totalWarnings := 0, 0
+
+	for _, scope := range []string{"project", "global"} {
+		scopeResults, ok := byScope[scope]
+		if !ok {
+			continue
+		}
+		scopeTitle := strings.ToUpper(scope[:1]) + scope[1:]
+		fmt.Printf("%s%s skills:%s\n\n", ansiText, scopeTitle, ansiReset)
+
+		for _, r := range scopeResults {
+			errCount, warnCount := 0, 0
+			for _, issue := range r.Issues {
+				switch issue.Level {
+				case "error":
+					errCount++
+				case "warn":
+					warnCount++
+				}
+			}
+			totalErrors += errCount
+			totalWarnings += warnCount
+
+			statusIcon, statusColor := doctorStatusIcon(errCount, warnCount)
+			fmt.Printf("  %s%s%s %s%s%s\n", statusColor, statusIcon, ansiReset, ansiBold, r.Name, ansiReset)
+
+			if len(r.Issues) == 0 {
+				fmt.Printf("    %s%s%s\n", ansiDim, shortenPath(r.Path, cwd), ansiReset)
+			} else {
+				for _, issue := range r.Issues {
+					icon, color := doctorIssueIcon(issue.Level)
+					fmt.Printf("    %s%s%s %s%s%s\n", color, icon, ansiReset, ansiDim, issue.Message, ansiReset)
+				}
+			}
+			fmt.Println()
+		}
+	}
+
+	// Instruction files section
+	if len(instrIssues) > 0 {
+		fmt.Printf("%sProject files:%s\n\n", ansiText, ansiReset)
+		for _, issue := range instrIssues {
+			icon, color := doctorIssueIcon(issue.Level)
+			fmt.Printf("  %s%s%s %s%s%s\n", color, icon, ansiReset, ansiDim, issue.Message, ansiReset)
+			if issue.Level == "error" {
+				totalErrors++
+			} else {
+				totalWarnings++
+			}
+		}
+		fmt.Println()
+	}
+
+	// Summary
+	total := len(results)
+	fmt.Printf("%sDoctor complete:%s %d skill(s) checked", ansiText, ansiReset, total)
+	if totalErrors > 0 {
+		fmt.Printf(", %s%d error(s)%s", ansiRed, totalErrors, ansiReset)
+	}
+	if totalWarnings > 0 {
+		fmt.Printf(", %s%d warning(s)%s", ansiYellow, totalWarnings, ansiReset)
+	}
+	if totalErrors == 0 && totalWarnings == 0 {
+		fmt.Printf(", %sall clear%s", ansiGreen, ansiReset)
+	}
+	fmt.Println()
+	fmt.Println()
+}
+
+func doctorStatusIcon(errors, warnings int) (icon, color string) {
+	switch {
+	case errors > 0:
+		return "✗", ansiRed
+	case warnings > 0:
+		return "▲", ansiYellow
+	default:
+		return "✓", ansiGreen
+	}
+}
+
+func doctorIssueIcon(level string) (icon, color string) {
+	if level == "error" {
+		return "✗", ansiRed
+	}
+	return "▲", ansiYellow
+}
+
+func formatFileSize(n int64) string {
+	if n >= 1024*1024 {
+		return fmt.Sprintf("%.1fMB", float64(n)/(1024*1024))
+	}
+	return fmt.Sprintf("%.0fKB", float64(n)/1024)
+}

--- a/src/commands/doctor.go
+++ b/src/commands/doctor.go
@@ -64,7 +64,7 @@ func buildDoctorCmd() *cobra.Command {
 Checks performed:
   • Missing skill directories or SKILL.md files
   • Broken symlinks in agent skill directories
-  • Skills modified since install (hash mismatch)
+  • Skills modified since install (hash mismatch; global installs with a recorded hash only)
   • Markdown files inside skill directories that are too large
   • Oversized agent instruction files (CLAUDE.md, AGENTS.md, .cursorrules, etc.)
   • All other .md files in the project that may strain agent context windows
@@ -128,13 +128,19 @@ func runDoctor(opts DoctorOptions) {
 			results = append(results, r)
 		}
 
-		// All agent skill directories
-		skipDirs[filepath.Clean(canonicalBase)] = true
+		// Only skip agent skill directories that actually exist on disk, to avoid
+		// accidentally suppressing real project folders from the markdown scan.
+		if _, err := os.Stat(canonicalBase); err == nil {
+			skipDirs[filepath.Clean(canonicalBase)] = true
+		}
 		for _, agentCfg := range agent.AllAgents {
 			if agentCfg == nil {
 				continue
 			}
-			skipDirs[filepath.Clean(filepath.Join(cwd, agentCfg.SkillsDir))] = true
+			agentSkillsDir := filepath.Clean(filepath.Join(cwd, agentCfg.SkillsDir))
+			if _, err := os.Stat(agentSkillsDir); err == nil {
+				skipDirs[agentSkillsDir] = true
+			}
 			if agentCfg.InstructionsFile != "" {
 				skipFiles[filepath.Clean(filepath.Join(cwd, agentCfg.InstructionsFile))] = true
 			}
@@ -181,7 +187,12 @@ func diagnoseSkill(r *doctorResult, storedHash string, global bool, cwd string) 
 		})
 	} else {
 		sk, err := skill.ParseSkillMd(skillMdPath, true)
-		if err != nil || sk == nil {
+		if err != nil {
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "error",
+				Message: fmt.Sprintf("SKILL.md could not be read: %s", err),
+			})
+		} else if sk == nil {
 			r.Issues = append(r.Issues, doctorIssue{
 				Level:   "warn",
 				Message: "SKILL.md is missing required name or description fields",
@@ -195,7 +206,12 @@ func diagnoseSkill(r *doctorResult, storedHash string, global bool, cwd string) 
 	// 4. Skill content must match the installed hash (global skills only)
 	if storedHash != "" {
 		current, err := lock.ComputeSkillFolderHash(r.Path)
-		if err == nil && current != storedHash {
+		if err != nil {
+			r.Issues = append(r.Issues, doctorIssue{
+				Level:   "warn",
+				Message: fmt.Sprintf("could not compute skill content hash — integrity check skipped: %s", err),
+			})
+		} else if current != storedHash {
 			r.Issues = append(r.Issues, doctorIssue{
 				Level:   "warn",
 				Message: "skill content differs from installed version — run `mdm skills update` to sync",
@@ -250,10 +266,17 @@ func checkAgentLinks(r *doctorResult, global bool, cwd string) {
 }
 
 // checkLargeMarkdown walks the skill directory and flags .md files that are
-// large enough to threaten agent context windows.
+// large enough to threaten agent context windows. Common dependency/build
+// directories (e.g. .git, node_modules, vendor) are skipped.
 func checkLargeMarkdown(r *doctorResult) {
 	_ = filepath.WalkDir(r.Path, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if markdownSkipDirNames[d.Name()] {
+				return fs.SkipDir
+			}
 			return nil
 		}
 		if !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {

--- a/src/commands/doctor_test.go
+++ b/src/commands/doctor_test.go
@@ -1,0 +1,530 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sethcarney/mdm/internal/lock"
+)
+
+// ── formatFileSize ─────────────────────────────────────────────────────────────
+
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{1024, "1KB"},
+		{20 * 1024, "20KB"},
+		{100 * 1024, "100KB"},
+		{1024 * 1024, "1.0MB"},
+		{2*1024*1024 + 512*1024, "2.5MB"},
+	}
+	for _, tc := range tests {
+		got := formatFileSize(tc.bytes)
+		if got != tc.expected {
+			t.Errorf("formatFileSize(%d) = %q, want %q", tc.bytes, got, tc.expected)
+		}
+	}
+}
+
+// ── diagnoseSkill: missing directory ──────────────────────────────────────────
+
+func TestDiagnoseSkillMissingDir(t *testing.T) {
+	r := &doctorResult{
+		Name:  "test-skill",
+		Scope: "global",
+		Path:  "/nonexistent/path/test-skill",
+	}
+	diagnoseSkill(r, "", false, t.TempDir())
+
+	if len(r.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(r.Issues), r.Issues)
+	}
+	if r.Issues[0].Level != "error" {
+		t.Errorf("expected error level, got %q", r.Issues[0].Level)
+	}
+	if !strings.Contains(r.Issues[0].Message, "skill directory not found") {
+		t.Errorf("unexpected message: %q", r.Issues[0].Message)
+	}
+}
+
+// ── diagnoseSkill: missing SKILL.md ───────────────────────────────────────────
+
+func TestDiagnoseSkillMissingSkillMd(t *testing.T) {
+	dir := t.TempDir()
+	r := &doctorResult{Name: "test-skill", Scope: "global", Path: dir}
+	diagnoseSkill(r, "", false, t.TempDir())
+
+	if len(r.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(r.Issues), r.Issues)
+	}
+	if r.Issues[0].Level != "error" {
+		t.Errorf("expected error level, got %q", r.Issues[0].Level)
+	}
+	if !strings.Contains(r.Issues[0].Message, "SKILL.md not found") {
+		t.Errorf("unexpected message: %q", r.Issues[0].Message)
+	}
+}
+
+// ── diagnoseSkill: SKILL.md read error surfaces as error (not warn) ───────────
+
+func TestDiagnoseSkillMdReadError(t *testing.T) {
+	dir := t.TempDir()
+	skillMd := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(skillMd, []byte("valid content"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// Running as root would bypass permissions; skip the test in that case.
+	if os.Getuid() == 0 {
+		t.Skip("skipping permission test when running as root")
+	}
+
+	r := &doctorResult{Name: "test-skill", Scope: "global", Path: dir}
+	diagnoseSkill(r, "", false, t.TempDir())
+
+	found := false
+	for _, issue := range r.Issues {
+		if issue.Level == "error" && strings.Contains(issue.Message, "SKILL.md could not be read") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an error issue about SKILL.md read failure, got: %v", r.Issues)
+	}
+}
+
+// ── diagnoseSkill: SKILL.md missing fields → warn, not error ─────────────────
+
+func TestDiagnoseSkillMdMissingFields(t *testing.T) {
+	dir := t.TempDir()
+	// Valid YAML but missing required name/description
+	content := "---\nauthor: someone\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "test-skill", Scope: "global", Path: dir}
+	diagnoseSkill(r, "", false, t.TempDir())
+
+	found := false
+	for _, issue := range r.Issues {
+		if issue.Level == "warn" && strings.Contains(issue.Message, "missing required name or description") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a warn about missing frontmatter fields, got: %v", r.Issues)
+	}
+}
+
+// ── diagnoseSkill: hash mismatch ──────────────────────────────────────────────
+
+func TestDiagnoseSkillHashMismatch(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: test\ndescription: A test skill\n---\nHello\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "test-skill", Scope: "global", Path: dir}
+	diagnoseSkill(r, "definitely-wrong-hash", false, t.TempDir())
+
+	found := false
+	for _, issue := range r.Issues {
+		if issue.Level == "warn" && strings.Contains(issue.Message, "skill content differs from installed version") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a warn about hash mismatch, got: %v", r.Issues)
+	}
+}
+
+// ── diagnoseSkill: hash matches → no mismatch issue ───────────────────────────
+
+func TestDiagnoseSkillHashMatch(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: test\ndescription: A test skill\n---\nHello\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hash, err := lock.ComputeSkillFolderHash(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "test-skill", Scope: "global", Path: dir}
+	diagnoseSkill(r, hash, false, t.TempDir())
+
+	for _, issue := range r.Issues {
+		if strings.Contains(issue.Message, "skill content differs") {
+			t.Errorf("unexpected hash-mismatch issue when hashes should match: %v", issue)
+		}
+		if strings.Contains(issue.Message, "integrity check skipped") {
+			t.Errorf("unexpected hash-error issue when hash should be computable: %v", issue)
+		}
+	}
+}
+
+// ── diagnoseSkill: hash error is surfaced as warn ─────────────────────────────
+
+func TestDiagnoseSkillHashError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping permission test when running as root")
+	}
+	dir := t.TempDir()
+	content := "---\nname: test\ndescription: A test skill\n---\nHello\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Create an unreadable subdirectory so hash computation fails
+	subDir := filepath.Join(dir, "assets")
+	if err := os.Mkdir(subDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(subDir, 0o755) //nolint:errcheck // cleanup best-effort
+
+	r := &doctorResult{Name: "test-skill", Scope: "global", Path: dir}
+	// Use a fake stored hash so we enter the hash-check branch
+	diagnoseSkill(r, "some-stored-hash", false, t.TempDir())
+
+	// Either a hash error OR a hash mismatch is acceptable — the important thing
+	// is that something is reported rather than silently ignored.
+	hasHashIssue := false
+	for _, issue := range r.Issues {
+		if strings.Contains(issue.Message, "integrity check skipped") ||
+			strings.Contains(issue.Message, "skill content differs") {
+			hasHashIssue = true
+		}
+	}
+	if !hasHashIssue {
+		t.Errorf("expected a hash-related issue, got: %v", r.Issues)
+	}
+}
+
+// ── checkLargeMarkdown: skips .git and node_modules ───────────────────────────
+
+func TestCheckLargeMarkdownSkipsDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Large .md file inside .git — must be skipped
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileOfSize(filepath.Join(gitDir, "COMMIT_EDITMSG.md"), fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Large .md file inside node_modules — must be skipped
+	nmDir := filepath.Join(dir, "node_modules")
+	if err := os.Mkdir(nmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileOfSize(filepath.Join(nmDir, "README.md"), fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Small SKILL.md in root — should NOT generate a size issue
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: t\ndescription: d\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "test", Path: dir}
+	checkLargeMarkdown(r)
+
+	for _, issue := range r.Issues {
+		if strings.Contains(issue.Message, ".git") || strings.Contains(issue.Message, "node_modules") {
+			t.Errorf("checkLargeMarkdown should have skipped %s, but got issue: %v", issue.Message, issue)
+		}
+	}
+}
+
+// ── checkLargeMarkdown: detects oversized files ───────────────────────────────
+
+func TestCheckLargeMarkdownDetectsOversized(t *testing.T) {
+	dir := t.TempDir()
+
+	// Warn-level file (20KB ≤ size < 100KB)
+	if err := writeFileOfSize(filepath.Join(dir, "warn.md"), fileSizeWarnBytes+1); err != nil {
+		t.Fatal(err)
+	}
+	// Error-level file (≥ 100KB)
+	if err := writeFileOfSize(filepath.Join(dir, "big.md"), fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "test", Path: dir}
+	checkLargeMarkdown(r)
+
+	warnFound, errFound := false, false
+	for _, issue := range r.Issues {
+		switch issue.Level {
+		case "warn":
+			warnFound = true
+		case "error":
+			errFound = true
+		}
+	}
+	if !warnFound {
+		t.Error("expected a warn issue for the 20KB+ file")
+	}
+	if !errFound {
+		t.Error("expected an error issue for the 100KB+ file")
+	}
+}
+
+// ── checkProjectMarkdown: skips non-existent dirs in skipDirs ─────────────────
+
+func TestCheckProjectMarkdownSkipsExistingDirs(t *testing.T) {
+	root := t.TempDir()
+
+	// Create a real skills dir with a large markdown file
+	skillsDir := filepath.Join(root, ".agents", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileOfSize(filepath.Join(skillsDir, "SKILL.md"), fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Non-existent dir added to skipDirs — should not cause a panic or side effects
+	skipDirs := map[string]bool{
+		filepath.Clean(skillsDir):                     true,
+		filepath.Join(root, "nonexistent-agent-dir"): true,
+	}
+
+	issues, _ := checkProjectMarkdown(root, skipDirs, map[string]bool{})
+
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, ".agents") {
+			t.Errorf("checkProjectMarkdown should skip the skills dir, but got: %v", issue)
+		}
+	}
+}
+
+// ── checkProjectMarkdown: walk limit triggers truncation ──────────────────────
+
+func TestCheckProjectMarkdownTruncation(t *testing.T) {
+	// Override the walk limit temporarily to a very small number.
+	// We do this by building a directory with many entries.
+	root := t.TempDir()
+	// Create markdownWalkLimit+10 files so the scan is forced to truncate.
+	// To avoid actually creating 10000 files we test at a tiny scale by
+	// verifying that truncated is false when limit is not reached.
+	issues, truncated := checkProjectMarkdown(root, map[string]bool{}, map[string]bool{})
+	if truncated {
+		t.Error("expected truncated=false for an empty directory")
+	}
+	_ = issues
+}
+
+// ── checkProjectMarkdown: skips .git ─────────────────────────────────────────
+
+func TestCheckProjectMarkdownSkipsGit(t *testing.T) {
+	root := t.TempDir()
+
+	gitDir := filepath.Join(root, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileOfSize(filepath.Join(gitDir, "COMMIT_EDITMSG.md"), fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	issues, _ := checkProjectMarkdown(root, map[string]bool{}, map[string]bool{})
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, ".git") {
+			t.Errorf("should have skipped .git dir but got: %v", issue)
+		}
+	}
+}
+
+// ── checkInstructionFiles ─────────────────────────────────────────────────────
+
+func TestCheckInstructionFilesDetectsOversized(t *testing.T) {
+	cwd := t.TempDir()
+
+	claudeMd := filepath.Join(cwd, "CLAUDE.md")
+	if err := writeFileOfSize(claudeMd, fileSizeWarnBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	issues := checkInstructionFiles(cwd)
+
+	found := false
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "CLAUDE.md") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected an issue for oversized CLAUDE.md")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// writeFileOfSize creates a file filled with 'x' bytes of the given size.
+func writeFileOfSize(path string, size int) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = 'x'
+	}
+	_, err = f.Write(buf)
+	return err
+}
+
+// TestDoctorIssueIcon verifies the icon/color mapping.
+func TestDoctorIssueIcon(t *testing.T) {
+	icon, color := doctorIssueIcon("error")
+	if icon != "✗" {
+		t.Errorf("expected ✗ for error, got %q", icon)
+	}
+	_ = color
+
+	icon, _ = doctorIssueIcon("warn")
+	if icon != "▲" {
+		t.Errorf("expected ▲ for warn, got %q", icon)
+	}
+}
+
+// TestDoctorStatusIcon verifies the status icon logic.
+func TestDoctorStatusIcon(t *testing.T) {
+	tests := []struct {
+		errors, warnings int
+		wantIcon         string
+	}{
+		{1, 0, "✗"},
+		{0, 1, "▲"},
+		{0, 0, "✓"},
+	}
+	for _, tc := range tests {
+		icon, _ := doctorStatusIcon(tc.errors, tc.warnings)
+		if icon != tc.wantIcon {
+			t.Errorf("doctorStatusIcon(%d, %d) = %q, want %q", tc.errors, tc.warnings, icon, tc.wantIcon)
+		}
+	}
+}
+
+// TestFormatFileSizeEdgeCases covers MB threshold and exact boundary.
+func TestFormatFileSizeEdgeCases(t *testing.T) {
+	// Exactly at MB boundary
+	got := formatFileSize(1024 * 1024)
+	if got != "1.0MB" {
+		t.Errorf("got %q, want 1.0MB", got)
+	}
+	// Just below MB
+	got = formatFileSize(1024*1024 - 1)
+	if !strings.HasSuffix(got, "KB") {
+		t.Errorf("expected KB suffix for sub-MB size, got %q", got)
+	}
+}
+
+// TestCheckProjectMarkdownSkipsFiles verifies that skipFiles prevents reporting.
+func TestCheckProjectMarkdownSkipsFiles(t *testing.T) {
+	root := t.TempDir()
+	bigFile := filepath.Join(root, "big.md")
+	if err := writeFileOfSize(bigFile, fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	skipFiles := map[string]bool{filepath.Clean(bigFile): true}
+	issues, _ := checkProjectMarkdown(root, map[string]bool{}, skipFiles)
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "big.md") {
+			t.Errorf("skipFiles should have suppressed this issue: %v", issue)
+		}
+	}
+}
+
+// TestCheckProjectMarkdownFindsLargeFiles confirms detection still works for
+// files that are not in skipDirs/skipFiles.
+func TestCheckProjectMarkdownFindsLargeFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := writeFileOfSize(filepath.Join(root, "huge.md"), fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	issues, _ := checkProjectMarkdown(root, map[string]bool{}, map[string]bool{})
+	found := false
+	for _, issue := range issues {
+		if issue.Level == "error" && strings.Contains(issue.Message, "huge.md") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an error issue for huge.md, got: %v", issues)
+	}
+}
+
+// TestCheckLargeMarkdownSmallFiles ensures small files produce no issues.
+func TestCheckLargeMarkdownSmallFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: t\ndescription: d\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "test", Path: dir}
+	checkLargeMarkdown(r)
+
+	if len(r.Issues) != 0 {
+		t.Errorf("expected no issues for small files, got: %v", r.Issues)
+	}
+}
+
+// TestCheckLargeMarkdownVendorSkipped ensures 'vendor' dir is skipped.
+func TestCheckLargeMarkdownVendorSkipped(t *testing.T) {
+	dir := t.TempDir()
+	vendorDir := filepath.Join(dir, "vendor")
+	if err := os.Mkdir(vendorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileOfSize(filepath.Join(vendorDir, "README.md"), fileSizeErrorBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "test", Path: dir}
+	checkLargeMarkdown(r)
+
+	for _, issue := range r.Issues {
+		if strings.Contains(issue.Message, "vendor") {
+			t.Errorf("checkLargeMarkdown should skip vendor/, got: %v", issue)
+		}
+	}
+}
+
+// TestDiagnoseSkillHealthySkill ensures a well-formed skill directory reports
+// no issues (except possibly agent-link checks that won't have links on disk).
+func TestDiagnoseSkillHealthySkill(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: My Skill\ndescription: A healthy skill\n---\nDo stuff.\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hash, err := lock.ComputeSkillFolderHash(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &doctorResult{Name: "my-skill", Scope: "global", Path: dir}
+	diagnoseSkill(r, hash, false, t.TempDir())
+
+	if len(r.Issues) != 0 {
+		t.Errorf("expected no issues for a healthy skill, got: %v", r.Issues)
+	}
+}
+
+// Silence compiler warning about fmt import.
+var _ = fmt.Sprintf

--- a/src/commands/doctor_test.go
+++ b/src/commands/doctor_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -525,6 +524,3 @@ func TestDiagnoseSkillHealthySkill(t *testing.T) {
 		t.Errorf("expected no issues for a healthy skill, got: %v", r.Issues)
 	}
 }
-
-// Silence compiler warning about fmt import.
-var _ = fmt.Sprintf

--- a/src/commands/root.go
+++ b/src/commands/root.go
@@ -111,6 +111,7 @@ func BuildRootCmd(ver string) *cobra.Command {
 	root.AddCommand(
 		buildSkillsCmd(ver),
 		buildRulesCmd(),
+		buildDoctorCmd(),
 		buildUpgradeCmd(ver),
 		buildCompletionCmd(root),
 	)

--- a/src/commands/root.go
+++ b/src/commands/root.go
@@ -94,7 +94,7 @@ func BuildRootCmd(ver string) *cobra.Command {
 			ansiGreen, ansiReset, ansiDim, ansiReset,
 			ansiGreen, ansiReset, ansiDim, ansiReset,
 			ansiGreen, ansiReset, ansiDim, ansiReset),
-		Example: "  mdm skills add https://github.com/anthropics/skills --skill frontend-design\n  mdm skills add https://github.com/vercel-labs/agent-skills --skill vercel-react-best-practices",
+		Example:       "  mdm skills add https://github.com/anthropics/skills --skill frontend-design\n  mdm skills add https://github.com/vercel-labs/agent-skills --skill vercel-react-best-practices",
 		Version:       ver,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -111,7 +111,6 @@ func BuildRootCmd(ver string) *cobra.Command {
 	root.AddCommand(
 		buildSkillsCmd(ver),
 		buildRulesCmd(),
-		buildDoctorCmd(),
 		buildUpgradeCmd(ver),
 		buildCompletionCmd(root),
 	)

--- a/src/commands/skills.go
+++ b/src/commands/skills.go
@@ -46,6 +46,7 @@ func buildSkillsCmd(ver string) *cobra.Command {
 		buildFindCmd(),
 		buildUpdateCmd(),
 		buildAuditCmd(),
+		buildDoctorCmd(),
 		buildInitCmd(ver),
 		buildInstallFromLockCmd(ver),
 		buildSyncCmd(ver),

--- a/src/commands/skills.go
+++ b/src/commands/skills.go
@@ -46,7 +46,6 @@ func buildSkillsCmd(ver string) *cobra.Command {
 		buildFindCmd(),
 		buildUpdateCmd(),
 		buildAuditCmd(),
-		buildDoctorCmd(),
 		buildInitCmd(ver),
 		buildInstallFromLockCmd(ver),
 		buildSyncCmd(ver),

--- a/src/tests/cli_test.go
+++ b/src/tests/cli_test.go
@@ -151,8 +151,19 @@ func TestAuditHelp(t *testing.T) {
 	}
 }
 
+func TestDoctorHelp(t *testing.T) {
+	stdout, _, code := runMdm(t, "doctor", "--help")
+	if code != 0 {
+		t.Fatalf("mdm doctor --help exited %d", code)
+	}
+	for _, expected := range []string{"--global", "--project", "hash mismatch"} {
+		if !strings.Contains(stdout, expected) {
+			t.Errorf("expected doctor --help output to contain %q, got: %q", expected, stdout)
+		}
+	}
+}
+
 func TestNormalizeMultiFlags(t *testing.T) {
-	// Run: mdm skills add owner/repo -a claude cursor --list
 	// This should NOT produce "unknown flag" or "flag needs an argument" in stderr.
 	// It will fail on network, but flag parsing should succeed.
 	_, stderr, _ := runMdm(t, "skills", "add", "owner/repo", "-a", "claude", "cursor", "--list")

--- a/src/tests/cli_test.go
+++ b/src/tests/cli_test.go
@@ -156,7 +156,7 @@ func TestDoctorHelp(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("mdm doctor --help exited %d", code)
 	}
-	for _, expected := range []string{"--global", "--project", "hash mismatch"} {
+	for _, expected := range []string{"--global", "--project", "hash mismatch; global installs"} {
 		if !strings.Contains(stdout, expected) {
 			t.Errorf("expected doctor --help output to contain %q, got: %q", expected, stdout)
 		}


### PR DESCRIPTION
Checks installed skills for five categories of issues:
- Missing skill directory or SKILL.md on disk
- Broken symlinks in non-universal agent directories
- Content hash mismatch vs. what was recorded at install time
- Markdown files ≥20 KB (warn) or ≥100 KB (error) that may strain
  agent context windows
- Oversized project instruction files (CLAUDE.md, AGENTS.md, etc.)

Supports --global / --project scope flags; defaults to both.

https://claude.ai/code/session_014XZRPtF2y22X4fhy8vapnt