### PR TITLE
Add fuzz tests for ParseSource and ParseFrontmatter

### DIFF
--- a/internal/skill/skill_fuzz_test.go
+++ b/internal/skill/skill_fuzz_test.go
@@ -1,0 +1,39 @@
+package skill
+
+import "testing"
+
+func FuzzParseFrontmatter(f *testing.F) {
+	seeds := []string{
+		// Valid frontmatter
+		"---\nname: my-skill\ndescription: A test skill\n---\n# Content",
+		"---\r\nname: my-skill\r\ndescription: A test skill\r\n---\r\n# Content",
+		"---\nname: skill\ndescription: desc\nmetadata:\n  internal: true\n---\nbody",
+		// No frontmatter
+		"# Just markdown content",
+		"plain text",
+		"",
+		// Malformed frontmatter
+		"---\n",
+		"---\nno closing delimiter",
+		"---\n---\n",
+		"---\ninvalid: yaml: :\n---\n",
+		"---\nnull\n---\n",
+		"---\n[invalid\n---\n",
+		// Edge cases
+		"---",
+		"---\n---",
+		"-",
+		"--",
+		"\x00",
+		"\n---\n",
+		"---\n" + string([]byte{0x00}) + "\n---\n",
+		// Large-ish YAML
+		"---\nname: n\ndescription: d\ntags:\n  - a\n  - b\n  - c\n---\nbody",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		ParseFrontmatter(input) // must not panic
+	})
+}

--- a/internal/source/source_fuzz_test.go
+++ b/internal/source/source_fuzz_test.go
@@ -1,0 +1,79 @@
+package source
+
+import "testing"
+
+func FuzzParseSource(f *testing.F) {
+	seeds := []string{
+		"github.com/foo/bar",
+		"github.com/foo/bar.git",
+		"https://github.com/foo/bar",
+		"https://github.com/foo/bar/tree/main",
+		"https://github.com/foo/bar/tree/main/skills",
+		"github:foo/bar",
+		"gitlab:foo/bar",
+		"https://gitlab.com/foo/bar",
+		"https://gitlab.com/foo/bar/-/tree/main",
+		"https://gitlab.com/foo/bar/-/tree/main/skills",
+		"foo/bar",
+		"foo/bar/subpath",
+		"foo/bar@skill-name",
+		"foo/bar#main",
+		"foo/bar#main@skill",
+		"./local/path",
+		"../relative/path",
+		"/absolute/path",
+		".",
+		"..",
+		"C:\\Windows\\Path",
+		"git@github.com:foo/bar.git",
+		"https://example.com/agent-skills",
+		"coinbase/agentWallet",
+		"",
+		"#",
+		"#@",
+		"github.com/",
+		"/",
+		"://",
+		"http://",
+		"https://",
+		"\x00",
+		"\n",
+		"foo/bar#" + string([]byte{0x00}),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		ParseSource(input) // must not panic
+	})
+}
+
+func FuzzIsLocalPath(f *testing.F) {
+	f.Add("./foo")
+	f.Add("../foo")
+	f.Add("/abs/path")
+	f.Add(".")
+	f.Add("..")
+	f.Add("C:\\foo")
+	f.Add("relative")
+	f.Add("")
+	f.Add("\x00")
+	f.Fuzz(func(t *testing.T, input string) {
+		IsLocalPath(input) // must not panic
+	})
+}
+
+func FuzzSanitizeSubpath(f *testing.F) {
+	f.Add("valid/path")
+	f.Add("../traversal")
+	f.Add("../../double")
+	f.Add("foo/../bar")
+	f.Add("\\backslash\\path")
+	f.Add("")
+	f.Add(".")
+	f.Add("..")
+	f.Add("\x00")
+	f.Fuzz(func(t *testing.T, input string) {
+		SanitizeSubpath(input) // must not panic
+	})
+}


### PR DESCRIPTION
Adds Go fuzz tests for the two highest-value input-parsing functions:
- FuzzParseSource, FuzzIsLocalPath, FuzzSanitizeSubpath in internal/source/
- FuzzParseFrontmatter in internal/skill/

Fulfills OpenSSF Scorecard Fuzzing check (issue #23).

https://claude.ai/code/session_01KVHGqfJBGRCv4yEKaffUDj