### PR TITLE
v1.1.0: Warn when a newer version is available

### DIFF
--- a/commands/selfupdate.go
+++ b/commands/selfupdate.go
@@ -11,11 +11,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/version"
 )
 
 const maxBinaryBytes = 100 * 1024 * 1024 // 100 MB hard cap
@@ -67,27 +68,6 @@ func getBinaryAssetName() string {
 		}
 	}
 	return ""
-}
-
-func isNewer(latest, current string) bool {
-	lParts := strings.Split(strings.TrimPrefix(latest, "v"), ".")
-	cParts := strings.Split(strings.TrimPrefix(current, "v"), ".")
-	for i := 0; i < 3; i++ {
-		var l, c int
-		if i < len(lParts) {
-			l, _ = strconv.Atoi(lParts[i])
-		}
-		if i < len(cParts) {
-			c, _ = strconv.Atoi(cParts[i])
-		}
-		if l > c {
-			return true
-		}
-		if l < c {
-			return false
-		}
-	}
-	return false
 }
 
 // isGitHubURL returns true only for github.com and its CDN hostnames.
@@ -147,7 +127,7 @@ func runSelfUpdate(currentVersion string) {
 
 	latestVersion := strings.TrimPrefix(release.TagName, "v")
 
-	if !isNewer(latestVersion, currentVersion) {
+	if !version.IsNewer(latestVersion, currentVersion) {
 		fmt.Printf("%sAlready up to date%s %s(%s)%s\n", ansiText, ansiReset, ansiDim, currentVersion, ansiReset)
 		return
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,143 @@
+package update
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const releasesAPI = "https://api.github.com/repos/sethcarney/mdm/releases/latest"
+const cacheTTL = 24 * time.Hour
+
+type cacheEntry struct {
+	LatestVersion string    `json:"latest_version"`
+	CheckedAt     time.Time `json:"checked_at"`
+}
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// CheckForUpdate starts a background goroutine that checks for a newer release.
+// It returns a channel that receives the latest version tag if one is available,
+// or an empty string if no update is found or the check fails.
+func CheckForUpdate(currentVersion string) <-chan string {
+	ch := make(chan string, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ch <- ""
+			}
+		}()
+		ch <- check(currentVersion)
+	}()
+	return ch
+}
+
+// IsTerminal reports whether stdout is an interactive terminal.
+func IsTerminal() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+func check(currentVersion string) string {
+	latest := fromCache()
+	if latest == "" {
+		latest = fromAPI(currentVersion)
+		if latest != "" {
+			saveCache(latest)
+		}
+	}
+	if isNewer(latest, currentVersion) {
+		return latest
+	}
+	return ""
+}
+
+func fromCache() string {
+	data, err := os.ReadFile(cacheFilePath())
+	if err != nil {
+		return ""
+	}
+	var entry cacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return ""
+	}
+	if time.Since(entry.CheckedAt) > cacheTTL {
+		return ""
+	}
+	return entry.LatestVersion
+}
+
+func saveCache(latest string) {
+	path := cacheFilePath()
+	_ = os.MkdirAll(filepath.Dir(path), 0755)
+	data, err := json.Marshal(cacheEntry{LatestVersion: latest, CheckedAt: time.Now()})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0644)
+}
+
+func cacheFilePath() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "mdm-update-check.json")
+	}
+	return filepath.Join(cacheDir, "mdm", "update-check.json")
+}
+
+func fromAPI(currentVersion string) string {
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("GET", releasesAPI, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("User-Agent", "mdm-cli/"+currentVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return ""
+	}
+	var release githubRelease
+	if err := json.Unmarshal(body, &release); err != nil {
+		return ""
+	}
+	return release.TagName
+}
+
+func isNewer(latest, current string) bool {
+	lParts := strings.Split(strings.TrimPrefix(latest, "v"), ".")
+	cParts := strings.Split(strings.TrimPrefix(current, "v"), ".")
+	for i := 0; i < 3; i++ {
+		var l, c int
+		if i < len(lParts) {
+			l, _ = strconv.Atoi(lParts[i])
+		}
+		if i < len(cParts) {
+			c, _ = strconv.Atoi(cParts[i])
+		}
+		if l > c {
+			return true
+		}
+		if l < c {
+			return false
+		}
+	}
+	return false
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
+
+	"github.com/sethcarney/mdm/internal/version"
 )
 
 const releasesAPI = "https://api.github.com/repos/sethcarney/mdm/releases/latest"
@@ -25,7 +25,7 @@ type githubRelease struct {
 
 // CheckForUpdate starts a background goroutine that checks for a newer release.
 // It returns a channel that receives the latest version tag if one is available,
-// or an empty string if no update is found or the check fails.
+// or an empty string otherwise. The check never fails loudly.
 func CheckForUpdate(currentVersion string) <-chan string {
 	ch := make(chan string, 1)
 	go func() {
@@ -49,32 +49,33 @@ func IsTerminal() bool {
 }
 
 func check(currentVersion string) string {
-	latest := fromCache()
-	if latest == "" {
+	hit, latest := fromCache()
+	if !hit {
 		latest = fromAPI(currentVersion)
-		if latest != "" {
-			saveCache(latest)
-		}
+		saveCache(latest) // always cache — even "" — to throttle retries
 	}
-	if isNewer(latest, currentVersion) {
+	if version.IsNewer(latest, currentVersion) {
 		return latest
 	}
 	return ""
 }
 
-func fromCache() string {
+// fromCache returns (hit, latestVersion). hit is false when the cache is
+// absent or older than cacheTTL; latestVersion may be "" (meaning the last
+// check found no update or the API was unreachable).
+func fromCache() (bool, string) {
 	data, err := os.ReadFile(cacheFilePath())
 	if err != nil {
-		return ""
+		return false, ""
 	}
 	var entry cacheEntry
 	if err := json.Unmarshal(data, &entry); err != nil {
-		return ""
+		return false, ""
 	}
 	if time.Since(entry.CheckedAt) > cacheTTL {
-		return ""
+		return false, ""
 	}
-	return entry.LatestVersion
+	return true, entry.LatestVersion
 }
 
 func saveCache(latest string) {
@@ -119,25 +120,4 @@ func fromAPI(currentVersion string) string {
 		return ""
 	}
 	return release.TagName
-}
-
-func isNewer(latest, current string) bool {
-	lParts := strings.Split(strings.TrimPrefix(latest, "v"), ".")
-	cParts := strings.Split(strings.TrimPrefix(current, "v"), ".")
-	for i := 0; i < 3; i++ {
-		var l, c int
-		if i < len(lParts) {
-			l, _ = strconv.Atoi(lParts[i])
-		}
-		if i < len(cParts) {
-			c, _ = strconv.Atoi(cParts[i])
-		}
-		if l > c {
-			return true
-		}
-		if l < c {
-			return false
-		}
-	}
-	return false
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -51,8 +51,18 @@ func IsTerminal() bool {
 func check(currentVersion string) string {
 	hit, latest := fromCache()
 	if !hit {
+		// Pre-write a sentinel ("") before making the network call.  If this
+		// process is killed during the HTTP request (e.g. because the 500 ms
+		// display window expired and main returned), the sentinel is already on
+		// disk and the next invocation will see a cache hit, preventing repeated
+		// API requests within the TTL window.
+		saveCache("")
 		latest = fromAPI(currentVersion)
-		saveCache(latest) // always cache — even "" — to throttle retries
+		if latest != "" {
+			// Overwrite the sentinel with the actual release tag so future
+			// cache hits can show the update notice without another API call.
+			saveCache(latest)
+		}
 	}
 	if version.IsNewer(latest, currentVersion) {
 		return latest

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-const Version = "1.0.0"
+const Version = "1.1.0"
 const AppName = "mdm"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,31 @@
 package version
 
+import (
+	"strconv"
+	"strings"
+)
+
 const Version = "1.1.0"
 const AppName = "mdm"
+
+// IsNewer reports whether latest is strictly greater than current (semver strings, "v" prefix optional).
+func IsNewer(latest, current string) bool {
+	lParts := strings.Split(strings.TrimPrefix(latest, "v"), ".")
+	cParts := strings.Split(strings.TrimPrefix(current, "v"), ".")
+	for i := 0; i < 3; i++ {
+		var l, c int
+		if i < len(lParts) {
+			l, _ = strconv.Atoi(lParts[i])
+		}
+		if i < len(cParts) {
+			c, _ = strconv.Atoi(cParts[i])
+		}
+		if l > c {
+			return true
+		}
+		if l < c {
+			return false
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -3,15 +3,31 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sethcarney/mdm/commands"
+	"github.com/sethcarney/mdm/internal/ui"
+	"github.com/sethcarney/mdm/internal/update"
 	"github.com/sethcarney/mdm/internal/version"
 )
 
 func main() {
+	updateCh := update.CheckForUpdate(version.Version)
+
 	root := commands.BuildRootCmd(version.Version)
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+
+	if update.IsTerminal() && os.Getenv("NO_COLOR") == "" {
+		select {
+		case latest := <-updateCh:
+			if latest != "" {
+				fmt.Printf("\n%sA new version of mdm is available: %s%s%s\n", ui.Yellow, ui.Bold, latest, ui.Reset)
+				fmt.Printf("%sUpdate now with: mdm upgrade%s\n", ui.Dim, ui.Reset)
+			}
+		case <-time.After(500 * time.Millisecond):
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -12,11 +12,12 @@ import (
 )
 
 func main() {
-	// Skip the update check when the user is already running an upgrade — the
-	// in-memory version.Version is stale after the binary is replaced, which
-	// would produce a false-positive "new version available" notice.
+	// Only start the background update check when the notice would actually be
+	// shown: interactive terminal, NO_COLOR not set, and not an upgrade command
+	// (the in-memory version.Version is stale after the binary is replaced,
+	// which would produce a false-positive "new version available" notice).
 	var updateCh <-chan string
-	if !isUpgradeCmd() {
+	if !isUpgradeCmd() && update.IsTerminal() && os.Getenv("NO_COLOR") == "" {
 		updateCh = update.CheckForUpdate(version.Version)
 	}
 
@@ -24,8 +25,8 @@ func main() {
 	cmdErr := root.Execute()
 
 	// Print the notice after command output (success or failure) so the user
-	// always sees it.  Suppress in non-TTY and NO_COLOR environments.
-	if updateCh != nil && update.IsTerminal() && os.Getenv("NO_COLOR") == "" {
+	// always sees it.
+	if updateCh != nil {
 		select {
 		case latest := <-updateCh:
 			if latest != "" {

--- a/main.go
+++ b/main.go
@@ -12,15 +12,20 @@ import (
 )
 
 func main() {
-	updateCh := update.CheckForUpdate(version.Version)
-
-	root := commands.BuildRootCmd(version.Version)
-	if err := root.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+	// Skip the update check when the user is already running an upgrade — the
+	// in-memory version.Version is stale after the binary is replaced, which
+	// would produce a false-positive "new version available" notice.
+	var updateCh <-chan string
+	if !isUpgradeCmd() {
+		updateCh = update.CheckForUpdate(version.Version)
 	}
 
-	if update.IsTerminal() && os.Getenv("NO_COLOR") == "" {
+	root := commands.BuildRootCmd(version.Version)
+	cmdErr := root.Execute()
+
+	// Print the notice after command output (success or failure) so the user
+	// always sees it.  Suppress in non-TTY and NO_COLOR environments.
+	if updateCh != nil && update.IsTerminal() && os.Getenv("NO_COLOR") == "" {
 		select {
 		case latest := <-updateCh:
 			if latest != "" {
@@ -30,4 +35,24 @@ func main() {
 		case <-time.After(500 * time.Millisecond):
 		}
 	}
+
+	if cmdErr != nil {
+		fmt.Fprintln(os.Stderr, cmdErr)
+		os.Exit(1)
+	}
+}
+
+// isUpgradeCmd reports whether the invocation is an upgrade/self-update command.
+func isUpgradeCmd() bool {
+	upgradeAliases := map[string]bool{
+		"upgrade":     true,
+		"update-cli":  true,
+		"self-update": true,
+	}
+	for _, arg := range os.Args[1:] {
+		if upgradeAliases[arg] {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Implements [#24](https://github.com/sethcarney/mdm/issues/24): after any `mdm` command completes, print a non-blocking notice if a newer release is available on GitHub
- Bumps version to `1.1.0`

## How it works

A new `internal/update` package handles the check:

- **Background goroutine** — started before `Execute()` so it runs concurrently with the command; the result is read (with a 500 ms timeout) after the command finishes
- **Per-user cache** — result written to `$XDG_CACHE_HOME/mdm/update-check.json`; valid for 24 hours so the GitHub API is hit at most once per day
- **Silent on failure** — all error paths return `""` and the goroutine has a `recover()` guard; API timeouts, bad JSON, or unreachable network are all ignored
- **TTY + NO_COLOR aware** — notice is suppressed when stdout is not an interactive terminal or `NO_COLOR` is set

Example output when an update is available:

```
A new version of mdm is available: v1.1.0
Update now with: mdm upgrade
```

## Test plan

- [ ] `make test` passes (all existing tests green)
- [ ] `make build` compiles cleanly
- [ ] Run `mdm skills list` on a machine where the cached version is older than the latest release — notice appears after output
- [ ] Run `mdm skills list | cat` (non-TTY) — no notice printed
- [ ] Run `NO_COLOR=1 mdm skills list` — no notice printed
- [ ] Kill network access and run any command — command succeeds, no error printed

https://claude.ai/code/session_015RQ3jTZkN19CmMMZMhyrRB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015RQ3jTZkN19CmMMZMhyrRB)_