### PR TITLE
fix: Scorecard Token-Permissions and SLSA pin documentation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: "0 10 * * 1" # Weekly on Monday
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze (Go)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,11 @@ jobs:
       actions: read
       id-token: write
       contents: write
+    # Note: slsa-github-generator reusable workflows MUST be referenced by tag,
+    # not by commit SHA. The generator reads github.action_ref at runtime to
+    # determine which binary release to download; a SHA reference breaks that
+    # lookup. This is a documented upstream requirement:
+    # https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"


### PR DESCRIPTION
## Summary

Two small hardening fixes surfaced by OpenSSF Scorecard.

### Token-Permissions (score: 9 → 10)

`codeql.yml` was missing a top-level `permissions` declaration, which Scorecard flags as excessive default permissions.

**Fix:** Added `permissions: read-all` at the workflow level — the job-level overrides already grant only what is needed.

### Pinned-Dependencies — SLSA generator comment

Scorecard warns that `slsa-framework/slsa-github-generator` is not pinned by commit SHA. This is a **known upstream constraint**: the SLSA generator reusable workflow reads `github.action_ref` at runtime to decide which binary to download; a SHA reference breaks that lookup.

**Fix:** Added an inline comment explaining the reason so future reviewers (and automated tools) understand why this is intentional.

> See: https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators

Closes part of #34