### PR TITLE
auto-link rules and install locked skills when adding a new agent

### DIFF
--- a/commands/add.go
+++ b/commands/add.go
@@ -754,7 +754,7 @@ func validateNamedAgents(names []string) ([]string, bool) {
 	return validated, true
 }
 
-func buildInstalledNonUniversal(detected []string) []string {
+func buildDetectedUniqueAgents(detected []string) []string {
 	var result []string
 	for _, a := range agent.GetUniqueSkillsDirAgents() {
 		for _, d := range detected {
@@ -767,9 +767,9 @@ func buildInstalledNonUniversal(detected []string) []string {
 	return result
 }
 
-func buildNonUniversalOptions(installedNonUniversal []string, global bool) []ui.UIOption {
+func buildUniqueAgentOptions(detectedUnique []string, global bool) []ui.UIOption {
 	var options []ui.UIOption
-	for _, a := range installedNonUniversal {
+	for _, a := range detectedUnique {
 		cfg := agent.AllAgents[a]
 		if cfg == nil || (global && cfg.GlobalSkillsDir == "") {
 			continue
@@ -806,7 +806,7 @@ func buildLockedAgentOptions(global bool) []ui.UIOption {
 	return lockedOptions
 }
 
-func computeAgentInitSel(options []ui.UIOption, installedNonUniversal []string, lastSelected []string) []int {
+func computeAgentInitSel(options []ui.UIOption, detectedUnique []string, lastSelected []string) []int {
 	lastSelectedSet := map[string]bool{}
 	for _, a := range lastSelected {
 		lastSelectedSet[a] = true
@@ -819,7 +819,7 @@ func computeAgentInitSel(options []ui.UIOption, installedNonUniversal []string, 
 	}
 	if len(initSel) == 0 {
 		for i, opt := range options {
-			for _, d := range installedNonUniversal {
+			for _, d := range detectedUnique {
 				if opt.Value == d {
 					initSel = append(initSel, i)
 					break
@@ -879,8 +879,8 @@ func promptAgents(opts AddOptions, global bool, cwd string) ([]string, bool) {
 	}
 
 	detected := agent.DetectInstalledAgents()
-	installedNonUniversal := buildInstalledNonUniversal(detected)
-	options := buildNonUniversalOptions(installedNonUniversal, global)
+	detectedUnique := buildDetectedUniqueAgents(detected)
+	options := buildUniqueAgentOptions(detectedUnique, global)
 	lockedOptions := buildLockedAgentOptions(global)
 
 	// If the user has a configured agent list for this scope, use it as the
@@ -903,7 +903,7 @@ func promptAgents(opts AddOptions, global bool, cwd string) ([]string, bool) {
 		return result, true
 	}
 
-	initSel := computeAgentInitSel(options, installedNonUniversal, configured)
+	initSel := computeAgentInitSel(options, detectedUnique, configured)
 	selectedIndices, ok := ui.UiSearchMultiselect("Which agents would you like to install to?", options, lockedOptions, initSel)
 	if !ok {
 		return nil, false

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -199,7 +199,16 @@ func pickAndSaveAgents(global bool, scope, cwd string) ([]string, error) {
 		return nil, fmt.Errorf("saving agents: %w", err)
 	}
 	printAgentsSaved(newList, scope)
-	return newList, nil
+
+	// Return only newly added agents so setup only runs for them, not for
+	// agents that were already configured before this invocation.
+	var newlyAdded []string
+	for _, name := range newList {
+		if !currentSet[name] {
+			newlyAdded = append(newlyAdded, name)
+		}
+	}
+	return newlyAdded, nil
 }
 
 func promptAgentScope() (isGlobal bool, ok bool) {
@@ -377,21 +386,40 @@ func runAgentSetup(agentNames []string, cwd string) {
 
 // linkNewAgentRules links each agent's instruction file to AGENTS.md when
 // AGENTS.md already exists as a real (non-symlink) file in the project directory.
+// Instruction files that already exist as real files are skipped with a hint to
+// run `mdm rules link` instead, to avoid silent data loss.
 func linkNewAgentRules(agentNames []string, cwd string) {
 	agentsMDPath := filepath.Join(cwd, agentsMDFile)
 	info, err := os.Lstat(agentsMDPath)
-	if err != nil || info.Mode()&os.ModeSymlink != 0 {
+	if err != nil || !info.Mode().IsRegular() {
 		return
 	}
 
 	var toLink []agentCandidate
+	var skippedFiles []string
 	for _, name := range agentNames {
 		cfg := agent.AllAgents[name]
 		if cfg == nil || cfg.NativeInstructions {
 			continue
 		}
+		targetPath := filepath.Join(cwd, cfg.InstructionsFile)
+		targetInfo, statErr := os.Lstat(targetPath)
+		if statErr == nil && targetInfo.Mode()&os.ModeSymlink == 0 {
+			// Existing real file — skip to avoid silent data loss.
+			skippedFiles = append(skippedFiles, cfg.InstructionsFile)
+			continue
+		}
 		toLink = append(toLink, agentCandidate{name: name, displayName: cfg.DisplayName, file: cfg.InstructionsFile})
 	}
+
+	if len(skippedFiles) > 0 {
+		fmt.Println()
+		for _, f := range skippedFiles {
+			fmt.Printf("  %s~%s %-35s %sskipped (existing file — run `mdm rules link` to replace)%s\n",
+				ansiYellow, ansiReset, f, ansiDim, ansiReset)
+		}
+	}
+
 	if len(toLink) == 0 {
 		return
 	}

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -106,7 +106,14 @@ Use %s--global%s / %s-g%s to configure agents at the user level.`, ansiBold, ans
 				if global {
 					scope = "global"
 				}
-				return pickAndSaveAgents(global, scope, cwd)
+				selected, err := pickAndSaveAgents(global, scope, cwd)
+				if err != nil {
+					return err
+				}
+				if len(selected) > 0 {
+					runAgentSetup(selected, cwd)
+				}
+				return nil
 			}
 
 			scope := "project"
@@ -129,6 +136,7 @@ Use %s--global%s / %s-g%s to configure agents at the user level.`, ansiBold, ans
 				fmt.Printf("%s✓%s Added %s%s%s to %s configured agents\n",
 					ansiGreen, ansiReset, ansiBold, displayName, ansiReset, scope)
 			}
+			runAgentSetup(toAdd, cwd)
 			return nil
 		},
 	}
@@ -140,8 +148,8 @@ Use %s--global%s / %s-g%s to configure agents at the user level.`, ansiBold, ans
 // configured list and replaces the entire list with the user's selection.
 // Truly universal agents (share .agents/skills AND have no unique instruction
 // file) are excluded from the picker — they are always supported and need no
-// configuration.
-func pickAndSaveAgents(global bool, scope, cwd string) error {
+// configuration. Returns the saved agent names so the caller can act on them.
+func pickAndSaveAgents(global bool, scope, cwd string) ([]string, error) {
 	current := lock.GetConfiguredAgents(global, cwd)
 	currentSet := map[string]bool{}
 	for _, a := range current {
@@ -176,7 +184,7 @@ func pickAndSaveAgents(global bool, scope, cwd string) error {
 
 	selected, ok := ui.UiSearchMultiselect("Which agents do you want to configure?", options, lockedOptions, initSel)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	var newList []string
 	for _, i := range selected {
@@ -184,14 +192,14 @@ func pickAndSaveAgents(global bool, scope, cwd string) error {
 	}
 	if len(newList) == 0 {
 		fmt.Printf("%sNo agents selected.%s\n", ansiDim, ansiReset)
-		return nil
+		return nil, nil
 	}
 	sort.Strings(newList)
 	if err := lock.SetConfiguredAgents(newList, global, cwd); err != nil {
-		return fmt.Errorf("saving agents: %w", err)
+		return nil, fmt.Errorf("saving agents: %w", err)
 	}
 	printAgentsSaved(newList, scope)
-	return nil
+	return newList, nil
 }
 
 func promptAgentScope() (isGlobal bool, ok bool) {
@@ -353,6 +361,126 @@ func cleanUpRemovedAgentFiles(toRemove []string, global bool, cwd string) {
 				ui.LogInfo("Removed " + cfg.InstructionsFile)
 			}
 		}
+	}
+}
+
+// ─── Agent setup (auto-link rules + install locked skills) ────────────────────
+
+// runAgentSetup links instruction files to AGENTS.md and installs any already-
+// locked skills for the newly configured agents. It is intentionally silent when
+// there is nothing to do so the happy-path output stays clean.
+func runAgentSetup(agentNames []string, cwd string) {
+	linkNewAgentRules(agentNames, cwd)
+	installLockedSkillsForAgents(agentNames, cwd)
+}
+
+// linkNewAgentRules links each agent's instruction file to AGENTS.md when
+// AGENTS.md already exists as a real (non-symlink) file in the project directory.
+func linkNewAgentRules(agentNames []string, cwd string) {
+	agentsMDPath := filepath.Join(cwd, agentsMDFile)
+	info, err := os.Lstat(agentsMDPath)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+
+	var toLink []agentCandidate
+	for _, name := range agentNames {
+		cfg := agent.AllAgents[name]
+		if cfg == nil || cfg.InstructionsFile == "" || cfg.InstructionsFile == agentsMDFile {
+			continue
+		}
+		toLink = append(toLink, agentCandidate{name: name, displayName: cfg.DisplayName, file: cfg.InstructionsFile})
+	}
+	if len(toLink) == 0 {
+		return
+	}
+
+	fmt.Println()
+	fmt.Printf("%sLinking instruction files → %s%s\n", ansiText, agentsMDFile, ansiReset)
+	fmt.Println()
+	createAgentSymlinks(toLink, cwd, agentsMDPath, true)
+}
+
+type skillLinkSpec struct {
+	skillName string
+	agentName string
+	global    bool
+}
+
+// agentsNeedingSkillLinks returns agents from agentNames that have a unique
+// (non-shared) skills directory and therefore need explicit skill linking.
+func agentsNeedingSkillLinks(agentNames []string) []string {
+	var result []string
+	for _, name := range agentNames {
+		if !agent.UsesSharedSkillsDir(name) && agent.AllAgents[name] != nil {
+			result = append(result, name)
+		}
+	}
+	return result
+}
+
+// collectSkillLinkSpecs gathers (skill, agent, global) triples for skills that
+// are recorded in either the project or global lock file but not yet installed
+// for the given target agents.
+func collectSkillLinkSpecs(targets []string, cwd string) []skillLinkSpec {
+	var specs []skillLinkSpec
+	localLk := lock.ReadLocalLock(cwd)
+	for skillName := range localLk.Skills {
+		for _, agentName := range targets {
+			if !isSkillInstalled(skillName, agentName, false) {
+				specs = append(specs, skillLinkSpec{skillName, agentName, false})
+			}
+		}
+	}
+	globalLk := lock.ReadSkillLock()
+	for skillName := range globalLk.Skills {
+		for _, agentName := range targets {
+			a := agent.AllAgents[agentName]
+			if a == nil || a.GlobalSkillsDir == "" {
+				continue
+			}
+			if !isSkillInstalled(skillName, agentName, true) {
+				specs = append(specs, skillLinkSpec{skillName, agentName, true})
+			}
+		}
+	}
+	return specs
+}
+
+// installLockedSkillsForAgents installs all locked skills (from the project and
+// global lock files) for agents that have a unique skills directory. Agents that
+// use the shared .agents/skills directory already have access to every installed
+// skill automatically and are skipped.
+func installLockedSkillsForAgents(agentNames []string, cwd string) {
+	targets := agentsNeedingSkillLinks(agentNames)
+	if len(targets) == 0 {
+		return
+	}
+	specs := collectSkillLinkSpecs(targets, cwd)
+	if len(specs) == 0 {
+		return
+	}
+
+	fmt.Println()
+	fmt.Printf("%sLinking skills from lock file...%s\n", ansiText, ansiReset)
+	fmt.Println()
+
+	succeeded := 0
+	for _, spec := range specs {
+		if !linkInstalledSkillToAgent(spec.skillName, spec.agentName, spec.global, cwd) {
+			continue
+		}
+		succeeded++
+		agentDisplay := spec.agentName
+		if cfg := agent.AllAgents[spec.agentName]; cfg != nil {
+			agentDisplay = cfg.DisplayName
+		}
+		fmt.Printf("  %s✓%s %-35s → %s\n", ansiGreen, ansiReset, spec.skillName, agentDisplay)
+	}
+	if succeeded > 0 {
+		fmt.Println()
+		ui.LogSuccess(fmt.Sprintf("Linked %d skill(s)", succeeded))
+		fmt.Println()
 	}
 }
 

--- a/commands/agents.go
+++ b/commands/agents.go
@@ -353,8 +353,9 @@ func cleanUpRemovedAgentFiles(toRemove []string, global bool, cwd string) {
 			}
 		}
 
-		// Remove the agent's instructions file (project scope only; skip shared AGENTS.md).
-		if !global && cfg.InstructionsFile != "" && cfg.InstructionsFile != "AGENTS.md" {
+		// Remove the agent's instructions file (project scope only; skip when
+		// the agent has no unique instructions file or reads AGENTS.md natively).
+		if !global && !cfg.NativeInstructions {
 			instrPath := filepath.Join(cwd, cfg.InstructionsFile)
 			if _, err := os.Lstat(instrPath); err == nil {
 				os.Remove(instrPath)
@@ -386,7 +387,7 @@ func linkNewAgentRules(agentNames []string, cwd string) {
 	var toLink []agentCandidate
 	for _, name := range agentNames {
 		cfg := agent.AllAgents[name]
-		if cfg == nil || cfg.InstructionsFile == "" || cfg.InstructionsFile == agentsMDFile {
+		if cfg == nil || cfg.NativeInstructions {
 			continue
 		}
 		toLink = append(toLink, agentCandidate{name: name, displayName: cfg.DisplayName, file: cfg.InstructionsFile})

--- a/commands/doctor.go
+++ b/commands/doctor.go
@@ -333,7 +333,7 @@ func checkUnlinkedRulesAgents(cwd string) []doctorIssue {
 	var issues []doctorIssue
 	for _, name := range configured {
 		cfg := agent.AllAgents[name]
-		if cfg == nil || cfg.InstructionsFile == "" || cfg.InstructionsFile == agentsMDFile {
+		if cfg == nil || cfg.NativeInstructions {
 			continue
 		}
 		instrPath := filepath.Join(cwd, cfg.InstructionsFile)
@@ -383,7 +383,7 @@ func checkMissingAgentSkillLinks(cwd string) []doctorIssue {
 		// Only flag agents whose rules file IS already linked (or they have no
 		// rules file — e.g. a pure-skills-dir agent). Agents whose rules file
 		// is missing are already reported by checkUnlinkedRulesAgents.
-		if cfg.InstructionsFile != "" && cfg.InstructionsFile != agentsMDFile {
+		if !cfg.NativeInstructions {
 			instrPath := filepath.Join(cwd, cfg.InstructionsFile)
 			info, err := os.Lstat(instrPath)
 			if err != nil || info.Mode()&os.ModeSymlink == 0 {

--- a/commands/installer.go
+++ b/commands/installer.go
@@ -649,6 +649,36 @@ func installWellKnownSkillForAgent(sk *registry.WellKnownSkill, agentName string
 	return installSkillFilesForAgent(sk.InstallName, files, agentName, global, mode)
 }
 
+// linkInstalledSkillToAgent symlinks (or copies) an already-installed skill's
+// canonical directory into the given agent's own skills directory.
+// Returns true when the agent's skill directory now exists (created or was already present).
+func linkInstalledSkillToAgent(skillName, agentName string, global bool, cwd string) bool {
+	a := agent.AllAgents[agentName]
+	if a == nil || (global && a.GlobalSkillsDir == "") {
+		return false
+	}
+	canonicalBase := getCanonicalSkillsDir(global, cwd)
+	canonicalDir := filepath.Join(canonicalBase, skillName)
+	if _, err := os.Stat(canonicalDir); err != nil {
+		return false
+	}
+	agentBase := getAgentBaseDir(agentName, global, cwd)
+	agentDir := filepath.Join(agentBase, skillName)
+	if !isPathSafe(canonicalBase, canonicalDir) || !isPathSafe(agentBase, agentDir) {
+		return false
+	}
+	if _, err := os.Stat(agentDir); err == nil {
+		return true // already present
+	}
+	if createSymlink(canonicalDir, agentDir) {
+		return true
+	}
+	if err := os.MkdirAll(agentBase, 0755); err != nil {
+		return false
+	}
+	return copyDirectory(canonicalDir, agentDir) == nil
+}
+
 // Silence unused imports
 var _ = fmt.Sprintf
 var _ = lock.ReadSkillLock

--- a/commands/rules.go
+++ b/commands/rules.go
@@ -106,7 +106,7 @@ func scanForExistingRuleFiles(cwd string) []ruleFile {
 	fileContent := map[string][]byte{}
 
 	for name, a := range agent.AllAgents {
-		if a.InstructionsFile == "" || a.InstructionsFile == agentsMDFile {
+		if a.NativeInstructions {
 			continue
 		}
 		fullPath := filepath.Join(cwd, a.InstructionsFile)
@@ -214,7 +214,7 @@ func buildLinkableCandidates() ([]agentCandidate, []ui.UIOption) {
 		if a.InstructionsFile == "" {
 			continue
 		}
-		if a.InstructionsFile == agentsMDFile {
+		if a.NativeInstructions {
 			lockedOptions = append(lockedOptions, ui.UIOption{Label: a.DisplayName, Value: name, Hint: "reads AGENTS.md natively"})
 			continue
 		}

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEX
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
@@ -46,6 +47,7 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -55,6 +57,7 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,14 +6,41 @@ import (
 	"strings"
 )
 
+// AgentConfig describes a single AI coding agent.
+//
+// The two boolean fields SharedSkillsDir and NativeInstructions are the
+// canonical source of truth for agent capability classification. All helper
+// functions (UsesSharedSkillsDir, NeedsNoTracking, …) read these fields.
+// Set them explicitly when adding a new agent; do not rely on path strings.
+//
+//	SharedSkillsDir  NativeInstructions  Meaning
+//	──────────────── ──────────────────  ────────────────────────────────────────
+//	false            false               needs both skills dir + rules symlink
+//	true             false               uses shared skills; needs rules symlink
+//	false            true                needs skills dir; rules auto-covered
+//	true             true                fully automatic; no configuration needed
 type AgentConfig struct {
-	Name             string
-	DisplayName      string
-	SkillsDir        string // relative, project-level
-	GlobalSkillsDir  string // absolute, user-level (empty = not supported)
-	AlwaysIncluded   bool   // show as locked/always-included in the agent picker
-	InstructionsFile string // project-root path to this agent's instructions file (empty = unknown)
-	DetectInstalled  func() bool
+	Name            string
+	DisplayName     string
+	SkillsDir       string // relative, project-level skills directory path
+	GlobalSkillsDir string // absolute, user-level path (empty = global not supported)
+	AlwaysIncluded  bool   // show as locked/always-included in the agent picker
+
+	// InstructionsFile is the project-root path to this agent's instruction
+	// file (e.g. "CLAUDE.md", ".cursorrules"). Empty means no instruction file.
+	InstructionsFile string
+
+	// SharedSkillsDir is true when this agent reads skills from the shared
+	// .agents/skills directory. Skills installed there are available
+	// automatically — no per-agent skills directory needs to be configured.
+	SharedSkillsDir bool
+
+	// NativeInstructions is true when this agent reads AGENTS.md natively or
+	// has no per-project instruction file. When true, no symlink to AGENTS.md
+	// is needed and configuredAgents does not need to track this agent for rules.
+	NativeInstructions bool
+
+	DetectInstalled func() bool
 }
 
 const AgentsDir = ".agents"
@@ -70,391 +97,522 @@ func init() {
 	codexHome := getCodexHome()
 	claudeHome := getClaudeHome()
 
-	AllAgents = map[string]*AgentConfig{
+	// ── SharedSkillsDir=true + NativeInstructions=false ────────────────────────
+	// Agents that use .agents/skills but have their own instruction file.
+	// Skills are auto-covered; only the rules symlink needs to be configured.
+
+	sharedSkillsUniqueRules := map[string]*AgentConfig{
 		"amp": {
-			Name:             "amp",
-			DisplayName:      "Amp",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(configHome, "agents/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: "AMP.md",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(configHome, "amp")) },
-		},
-		"antigravity": {
-			Name:            "antigravity",
-			DisplayName:     "Antigravity",
-			SkillsDir:       ".agents/skills",
-			GlobalSkillsDir: filepath.Join(home, ".gemini/antigravity/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".gemini/antigravity")) },
-		},
-		"augment": {
-			Name:            "augment",
-			DisplayName:     "Augment",
-			SkillsDir:       ".augment/skills",
-			GlobalSkillsDir: filepath.Join(home, ".augment/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".augment")) },
-		},
-		"bob": {
-			Name:            "bob",
-			DisplayName:     "IBM Bob",
-			SkillsDir:       ".bob/skills",
-			GlobalSkillsDir: filepath.Join(home, ".bob/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".bob")) },
-		},
-		"claude-code": {
-			Name:             "claude-code",
-			DisplayName:      "Claude Code",
-			SkillsDir:        ".claude/skills",
-			GlobalSkillsDir:  filepath.Join(claudeHome, "skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: "CLAUDE.md",
-			DetectInstalled:  func() bool { return pathExists(claudeHome) },
-		},
-		"openclaw": {
-			Name:            "openclaw",
-			DisplayName:     "OpenClaw",
-			SkillsDir:       "skills",
-			GlobalSkillsDir: getOpenClawGlobalSkillsDir(),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool {
-				return pathExists(filepath.Join(home, ".openclaw")) ||
-					pathExists(filepath.Join(home, ".clawdbot")) ||
-					pathExists(filepath.Join(home, ".moltbot"))
-			},
+			Name:               "amp",
+			DisplayName:        "Amp",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(configHome, "agents/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   "AMP.md",
+			SharedSkillsDir:    true,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(configHome, "amp")) },
 		},
 		"cline": {
-			Name:             "cline",
-			DisplayName:      "Cline",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(home, ".agents/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: ".clinerules",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(home, ".cline")) },
+			Name:               "cline",
+			DisplayName:        "Cline",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".agents/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   ".clinerules",
+			SharedSkillsDir:    true,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".cline")) },
+		},
+		"cursor": {
+			Name:               "cursor",
+			DisplayName:        "Cursor",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".cursor/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   ".cursorrules",
+			SharedSkillsDir:    true,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".cursor")) },
+		},
+		"gemini-cli": {
+			Name:               "gemini-cli",
+			DisplayName:        "Gemini CLI",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".gemini/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   "GEMINI.md",
+			SharedSkillsDir:    true,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".gemini")) },
+		},
+		"github-copilot": {
+			Name:               "github-copilot",
+			DisplayName:        "GitHub Copilot",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".copilot/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   ".github/copilot-instructions.md",
+			SharedSkillsDir:    true,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".copilot")) },
+		},
+	}
+
+	// ── SharedSkillsDir=true + NativeInstructions=true ─────────────────────────
+	// Fully automatic agents: skills come from .agents/skills and instructions
+	// are read from AGENTS.md (or this agent has no instruction file). No
+	// configuration in configuredAgents is needed for these agents.
+
+	fullyAutomatic := map[string]*AgentConfig{
+		"antigravity": {
+			Name:               "antigravity",
+			DisplayName:        "Antigravity",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".gemini/antigravity/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".gemini/antigravity")) },
+		},
+		"codex": {
+			Name:               "codex",
+			DisplayName:        "Codex",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(codexHome, "skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   "AGENTS.md",
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(codexHome) || pathExists("/etc/codex") },
+		},
+		"deepagents": {
+			Name:               "deepagents",
+			DisplayName:        "Deep Agents",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".deepagents/agent/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".deepagents")) },
+		},
+		"firebender": {
+			Name:               "firebender",
+			DisplayName:        "Firebender",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".firebender/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".firebender")) },
+		},
+		"kimi-cli": {
+			Name:               "kimi-cli",
+			DisplayName:        "Kimi Code CLI",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".config/agents/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kimi")) },
+		},
+		"opencode": {
+			Name:               "opencode",
+			DisplayName:        "OpenCode",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(configHome, "opencode/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   "AGENTS.md",
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(configHome, "opencode")) },
+		},
+		"replit": {
+			Name:               "replit",
+			DisplayName:        "Replit",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(configHome, "agents/skills"),
+			AlwaysIncluded:     false,
+			InstructionsFile:   "AGENTS.md",
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled: func() bool {
+				cwd, _ := os.Getwd()
+				return pathExists(filepath.Join(cwd, ".replit"))
+			},
+		},
+		"universal": {
+			Name:               "universal",
+			DisplayName:        "Universal",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(configHome, "agents/skills"),
+			AlwaysIncluded:     false,
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return false },
+		},
+		"warp": {
+			Name:               "warp",
+			DisplayName:        "Warp",
+			SkillsDir:          ".agents/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".agents/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    true,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".warp")) },
+		},
+	}
+
+	// ── SharedSkillsDir=false + NativeInstructions=false ───────────────────────
+	// Agents that need both a dedicated skills directory AND a rules symlink.
+	// Both must be explicitly configured via configuredAgents.
+
+	uniqueSkillsUniqueRules := map[string]*AgentConfig{
+		"claude-code": {
+			Name:               "claude-code",
+			DisplayName:        "Claude Code",
+			SkillsDir:          ".claude/skills",
+			GlobalSkillsDir:    filepath.Join(claudeHome, "skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   "CLAUDE.md",
+			SharedSkillsDir:    false,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(claudeHome) },
+		},
+		"roo": {
+			Name:               "roo",
+			DisplayName:        "Roo Code",
+			SkillsDir:          ".roo/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".roo/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   ".roorules",
+			SharedSkillsDir:    false,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".roo")) },
+		},
+		"windsurf": {
+			Name:               "windsurf",
+			DisplayName:        "Windsurf",
+			SkillsDir:          ".windsurf/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".codeium/windsurf/skills"),
+			AlwaysIncluded:     true,
+			InstructionsFile:   ".windsurfrules",
+			SharedSkillsDir:    false,
+			NativeInstructions: false,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".codeium/windsurf")) },
+		},
+	}
+
+	// ── SharedSkillsDir=false + NativeInstructions=true ────────────────────────
+	// Agents with their own dedicated skills directory but no per-project
+	// instruction file (or they read AGENTS.md natively). Only the skills
+	// directory needs to be configured via configuredAgents.
+
+	uniqueSkillsNativeRules := map[string]*AgentConfig{
+		"adal": {
+			Name:               "adal",
+			DisplayName:        "AdaL",
+			SkillsDir:          ".adal/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".adal/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".adal")) },
+		},
+		"augment": {
+			Name:               "augment",
+			DisplayName:        "Augment",
+			SkillsDir:          ".augment/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".augment/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".augment")) },
+		},
+		"bob": {
+			Name:               "bob",
+			DisplayName:        "IBM Bob",
+			SkillsDir:          ".bob/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".bob/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".bob")) },
 		},
 		"codebuddy": {
-			Name:            "codebuddy",
-			DisplayName:     "CodeBuddy",
-			SkillsDir:       ".codebuddy/skills",
-			GlobalSkillsDir: filepath.Join(home, ".codebuddy/skills"),
-			AlwaysIncluded:  true,
+			Name:               "codebuddy",
+			DisplayName:        "CodeBuddy",
+			SkillsDir:          ".codebuddy/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".codebuddy/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
 			DetectInstalled: func() bool {
 				cwd, _ := os.Getwd()
 				return pathExists(filepath.Join(cwd, ".codebuddy")) || pathExists(filepath.Join(home, ".codebuddy"))
 			},
 		},
-		"codex": {
-			Name:             "codex",
-			DisplayName:      "Codex",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(codexHome, "skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: "AGENTS.md",
-			DetectInstalled:  func() bool { return pathExists(codexHome) || pathExists("/etc/codex") },
-		},
 		"command-code": {
-			Name:            "command-code",
-			DisplayName:     "Command Code",
-			SkillsDir:       ".commandcode/skills",
-			GlobalSkillsDir: filepath.Join(home, ".commandcode/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".commandcode")) },
+			Name:               "command-code",
+			DisplayName:        "Command Code",
+			SkillsDir:          ".commandcode/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".commandcode/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".commandcode")) },
 		},
 		"continue": {
-			Name:            "continue",
-			DisplayName:     "Continue",
-			SkillsDir:       ".continue/skills",
-			GlobalSkillsDir: filepath.Join(home, ".continue/skills"),
-			AlwaysIncluded:  true,
+			Name:               "continue",
+			DisplayName:        "Continue",
+			SkillsDir:          ".continue/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".continue/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
 			DetectInstalled: func() bool {
 				cwd, _ := os.Getwd()
 				return pathExists(filepath.Join(cwd, ".continue")) || pathExists(filepath.Join(home, ".continue"))
 			},
 		},
 		"cortex": {
-			Name:            "cortex",
-			DisplayName:     "Cortex Code",
-			SkillsDir:       ".cortex/skills",
-			GlobalSkillsDir: filepath.Join(home, ".snowflake/cortex/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".snowflake/cortex")) },
+			Name:               "cortex",
+			DisplayName:        "Cortex Code",
+			SkillsDir:          ".cortex/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".snowflake/cortex/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".snowflake/cortex")) },
 		},
 		"crush": {
-			Name:            "crush",
-			DisplayName:     "Crush",
-			SkillsDir:       ".crush/skills",
-			GlobalSkillsDir: filepath.Join(home, ".config/crush/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".config/crush")) },
-		},
-		"cursor": {
-			Name:             "cursor",
-			DisplayName:      "Cursor",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(home, ".cursor/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: ".cursorrules",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(home, ".cursor")) },
-		},
-		"deepagents": {
-			Name:            "deepagents",
-			DisplayName:     "Deep Agents",
-			SkillsDir:       ".agents/skills",
-			GlobalSkillsDir: filepath.Join(home, ".deepagents/agent/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".deepagents")) },
+			Name:               "crush",
+			DisplayName:        "Crush",
+			SkillsDir:          ".crush/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".config/crush/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".config/crush")) },
 		},
 		"droid": {
-			Name:            "droid",
-			DisplayName:     "Droid",
-			SkillsDir:       ".factory/skills",
-			GlobalSkillsDir: filepath.Join(home, ".factory/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".factory")) },
-		},
-		"firebender": {
-			Name:            "firebender",
-			DisplayName:     "Firebender",
-			SkillsDir:       ".agents/skills",
-			GlobalSkillsDir: filepath.Join(home, ".firebender/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".firebender")) },
-		},
-		"gemini-cli": {
-			Name:             "gemini-cli",
-			DisplayName:      "Gemini CLI",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(home, ".gemini/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: "GEMINI.md",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(home, ".gemini")) },
-		},
-		"github-copilot": {
-			Name:             "github-copilot",
-			DisplayName:      "GitHub Copilot",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(home, ".copilot/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: ".github/copilot-instructions.md",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(home, ".copilot")) },
+			Name:               "droid",
+			DisplayName:        "Droid",
+			SkillsDir:          ".factory/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".factory/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".factory")) },
 		},
 		"goose": {
-			Name:            "goose",
-			DisplayName:     "Goose",
-			SkillsDir:       ".goose/skills",
-			GlobalSkillsDir: filepath.Join(configHome, "goose/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(configHome, "goose")) },
+			Name:               "goose",
+			DisplayName:        "Goose",
+			SkillsDir:          ".goose/skills",
+			GlobalSkillsDir:    filepath.Join(configHome, "goose/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(configHome, "goose")) },
 		},
 		"iflow-cli": {
-			Name:            "iflow-cli",
-			DisplayName:     "iFlow CLI",
-			SkillsDir:       ".iflow/skills",
-			GlobalSkillsDir: filepath.Join(home, ".iflow/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".iflow")) },
+			Name:               "iflow-cli",
+			DisplayName:        "iFlow CLI",
+			SkillsDir:          ".iflow/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".iflow/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".iflow")) },
 		},
 		"junie": {
-			Name:            "junie",
-			DisplayName:     "Junie",
-			SkillsDir:       ".junie/skills",
-			GlobalSkillsDir: filepath.Join(home, ".junie/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".junie")) },
+			Name:               "junie",
+			DisplayName:        "Junie",
+			SkillsDir:          ".junie/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".junie/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".junie")) },
 		},
 		"kilo": {
-			Name:            "kilo",
-			DisplayName:     "Kilo Code",
-			SkillsDir:       ".kilocode/skills",
-			GlobalSkillsDir: filepath.Join(home, ".kilocode/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".kilocode")) },
-		},
-		"kimi-cli": {
-			Name:            "kimi-cli",
-			DisplayName:     "Kimi Code CLI",
-			SkillsDir:       ".agents/skills",
-			GlobalSkillsDir: filepath.Join(home, ".config/agents/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".kimi")) },
+			Name:               "kilo",
+			DisplayName:        "Kilo Code",
+			SkillsDir:          ".kilocode/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".kilocode/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kilocode")) },
 		},
 		"kiro-cli": {
-			Name:            "kiro-cli",
-			DisplayName:     "Kiro CLI",
-			SkillsDir:       ".kiro/skills",
-			GlobalSkillsDir: filepath.Join(home, ".kiro/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".kiro")) },
+			Name:               "kiro-cli",
+			DisplayName:        "Kiro CLI",
+			SkillsDir:          ".kiro/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".kiro/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kiro")) },
 		},
 		"kode": {
-			Name:            "kode",
-			DisplayName:     "Kode",
-			SkillsDir:       ".kode/skills",
-			GlobalSkillsDir: filepath.Join(home, ".kode/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".kode")) },
+			Name:               "kode",
+			DisplayName:        "Kode",
+			SkillsDir:          ".kode/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".kode/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kode")) },
 		},
 		"mcpjam": {
-			Name:            "mcpjam",
-			DisplayName:     "MCPJam",
-			SkillsDir:       ".mcpjam/skills",
-			GlobalSkillsDir: filepath.Join(home, ".mcpjam/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".mcpjam")) },
+			Name:               "mcpjam",
+			DisplayName:        "MCPJam",
+			SkillsDir:          ".mcpjam/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".mcpjam/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".mcpjam")) },
 		},
 		"mistral-vibe": {
-			Name:            "mistral-vibe",
-			DisplayName:     "Mistral Vibe",
-			SkillsDir:       ".vibe/skills",
-			GlobalSkillsDir: filepath.Join(home, ".vibe/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".vibe")) },
+			Name:               "mistral-vibe",
+			DisplayName:        "Mistral Vibe",
+			SkillsDir:          ".vibe/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".vibe/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".vibe")) },
 		},
 		"mux": {
-			Name:            "mux",
-			DisplayName:     "Mux",
-			SkillsDir:       ".mux/skills",
-			GlobalSkillsDir: filepath.Join(home, ".mux/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".mux")) },
+			Name:               "mux",
+			DisplayName:        "Mux",
+			SkillsDir:          ".mux/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".mux/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".mux")) },
 		},
 		"neovate": {
-			Name:            "neovate",
-			DisplayName:     "Neovate",
-			SkillsDir:       ".neovate/skills",
-			GlobalSkillsDir: filepath.Join(home, ".neovate/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".neovate")) },
+			Name:               "neovate",
+			DisplayName:        "Neovate",
+			SkillsDir:          ".neovate/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".neovate/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".neovate")) },
 		},
-		"opencode": {
-			Name:             "opencode",
-			DisplayName:      "OpenCode",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(configHome, "opencode/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: "AGENTS.md",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(configHome, "opencode")) },
-		},
-		"openhands": {
-			Name:            "openhands",
-			DisplayName:     "OpenHands",
-			SkillsDir:       ".openhands/skills",
-			GlobalSkillsDir: filepath.Join(home, ".openhands/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".openhands")) },
-		},
-		"pi": {
-			Name:            "pi",
-			DisplayName:     "Pi",
-			SkillsDir:       ".pi/skills",
-			GlobalSkillsDir: filepath.Join(home, ".pi/agent/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".pi/agent")) },
-		},
-		"pochi": {
-			Name:            "pochi",
-			DisplayName:     "Pochi",
-			SkillsDir:       ".pochi/skills",
-			GlobalSkillsDir: filepath.Join(home, ".pochi/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".pochi")) },
-		},
-		"adal": {
-			Name:            "adal",
-			DisplayName:     "AdaL",
-			SkillsDir:       ".adal/skills",
-			GlobalSkillsDir: filepath.Join(home, ".adal/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".adal")) },
-		},
-		"qoder": {
-			Name:            "qoder",
-			DisplayName:     "Qoder",
-			SkillsDir:       ".qoder/skills",
-			GlobalSkillsDir: filepath.Join(home, ".qoder/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".qoder")) },
-		},
-		"qwen-code": {
-			Name:            "qwen-code",
-			DisplayName:     "Qwen Code",
-			SkillsDir:       ".qwen/skills",
-			GlobalSkillsDir: filepath.Join(home, ".qwen/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".qwen")) },
-		},
-		"replit": {
-			Name:             "replit",
-			DisplayName:      "Replit",
-			SkillsDir:        ".agents/skills",
-			GlobalSkillsDir:  filepath.Join(configHome, "agents/skills"),
-			AlwaysIncluded:   false,
-			InstructionsFile: "AGENTS.md",
+		"openclaw": {
+			Name:               "openclaw",
+			DisplayName:        "OpenClaw",
+			SkillsDir:          "skills",
+			GlobalSkillsDir:    getOpenClawGlobalSkillsDir(),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
 			DetectInstalled: func() bool {
-				cwd, _ := os.Getwd()
-				return pathExists(filepath.Join(cwd, ".replit"))
+				return pathExists(filepath.Join(home, ".openclaw")) ||
+					pathExists(filepath.Join(home, ".clawdbot")) ||
+					pathExists(filepath.Join(home, ".moltbot"))
 			},
 		},
-		"roo": {
-			Name:             "roo",
-			DisplayName:      "Roo Code",
-			SkillsDir:        ".roo/skills",
-			GlobalSkillsDir:  filepath.Join(home, ".roo/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: ".roorules",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(home, ".roo")) },
+		"openhands": {
+			Name:               "openhands",
+			DisplayName:        "OpenHands",
+			SkillsDir:          ".openhands/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".openhands/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".openhands")) },
+		},
+		"pi": {
+			Name:               "pi",
+			DisplayName:        "Pi",
+			SkillsDir:          ".pi/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".pi/agent/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".pi/agent")) },
+		},
+		"pochi": {
+			Name:               "pochi",
+			DisplayName:        "Pochi",
+			SkillsDir:          ".pochi/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".pochi/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".pochi")) },
+		},
+		"qoder": {
+			Name:               "qoder",
+			DisplayName:        "Qoder",
+			SkillsDir:          ".qoder/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".qoder/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".qoder")) },
+		},
+		"qwen-code": {
+			Name:               "qwen-code",
+			DisplayName:        "Qwen Code",
+			SkillsDir:          ".qwen/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".qwen/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".qwen")) },
 		},
 		"trae": {
-			Name:            "trae",
-			DisplayName:     "Trae",
-			SkillsDir:       ".trae/skills",
-			GlobalSkillsDir: filepath.Join(home, ".trae/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".trae")) },
+			Name:               "trae",
+			DisplayName:        "Trae",
+			SkillsDir:          ".trae/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".trae/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".trae")) },
 		},
 		"trae-cn": {
-			Name:            "trae-cn",
-			DisplayName:     "Trae CN",
-			SkillsDir:       ".trae/skills",
-			GlobalSkillsDir: filepath.Join(home, ".trae-cn/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".trae-cn")) },
-		},
-		"warp": {
-			Name:            "warp",
-			DisplayName:     "Warp",
-			SkillsDir:       ".agents/skills",
-			GlobalSkillsDir: filepath.Join(home, ".agents/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".warp")) },
-		},
-		"windsurf": {
-			Name:             "windsurf",
-			DisplayName:      "Windsurf",
-			SkillsDir:        ".windsurf/skills",
-			GlobalSkillsDir:  filepath.Join(home, ".codeium/windsurf/skills"),
-			AlwaysIncluded:   true,
-			InstructionsFile: ".windsurfrules",
-			DetectInstalled:  func() bool { return pathExists(filepath.Join(home, ".codeium/windsurf")) },
+			Name:               "trae-cn",
+			DisplayName:        "Trae CN",
+			SkillsDir:          ".trae/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".trae-cn/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".trae-cn")) },
 		},
 		"zencoder": {
-			Name:            "zencoder",
-			DisplayName:     "Zencoder",
-			SkillsDir:       ".zencoder/skills",
-			GlobalSkillsDir: filepath.Join(home, ".zencoder/skills"),
-			AlwaysIncluded:  true,
-			DetectInstalled: func() bool { return pathExists(filepath.Join(home, ".zencoder")) },
+			Name:               "zencoder",
+			DisplayName:        "Zencoder",
+			SkillsDir:          ".zencoder/skills",
+			GlobalSkillsDir:    filepath.Join(home, ".zencoder/skills"),
+			AlwaysIncluded:     true,
+			SharedSkillsDir:    false,
+			NativeInstructions: true,
+			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".zencoder")) },
 		},
-		"universal": {
-			Name:            "universal",
-			DisplayName:     "Universal",
-			SkillsDir:       ".agents/skills",
-			GlobalSkillsDir: filepath.Join(configHome, "agents/skills"),
-			AlwaysIncluded:  false,
-			DetectInstalled: func() bool { return false },
-		},
+	}
+
+	AllAgents = make(map[string]*AgentConfig)
+	for k, v := range sharedSkillsUniqueRules {
+		AllAgents[k] = v
+	}
+	for k, v := range fullyAutomatic {
+		AllAgents[k] = v
+	}
+	for k, v := range uniqueSkillsUniqueRules {
+		AllAgents[k] = v
+	}
+	for k, v := range uniqueSkillsNativeRules {
+		AllAgents[k] = v
 	}
 }
 
@@ -468,22 +626,17 @@ func DetectInstalledAgents() []string {
 	return installed
 }
 
-// ─── Three-category agent classification ──────────────────────────────────────
+// ─── Agent classification helpers ─────────────────────────────────────────────
 //
-// Category 1 — UsesSharedSkillsDir: skills are always auto-installed via
-// .agents/skills; no per-agent skills configuration is needed.
-//
-// Category 2 — UsesAgentsMD: AGENTS.md is always read for instructions; no
-// per-agent instructions configuration is needed.
-//
-// Category 3 — NeedsNoTracking (both): agent is in both categories above (or
-// has no instructions file at all), so it never needs to appear in
-// configuredAgents — everything is covered automatically.
+// These functions read the explicit SharedSkillsDir and NativeInstructions
+// boolean fields on AgentConfig. Do not add new string comparisons against
+// SkillsDir or InstructionsFile in calling code — use these helpers instead.
 
-// UsesSharedSkillsDir reports whether the agent reads skills from .agents/skills.
+// UsesSharedSkillsDir reports whether the agent reads skills from the shared
+// .agents/skills directory (SharedSkillsDir == true).
 func UsesSharedSkillsDir(name string) bool {
 	a, ok := AllAgents[name]
-	return ok && a.SkillsDir == ".agents/skills"
+	return ok && a.SharedSkillsDir
 }
 
 // UsesAgentsMD reports whether the agent reads instructions from AGENTS.md.
@@ -493,12 +646,11 @@ func UsesAgentsMD(name string) bool {
 }
 
 // NeedsNoTracking reports whether an agent requires no entry in configuredAgents.
-// This is true when skills are auto-covered (shared skills dir) AND instructions
-// are also auto-covered (AGENTS.md or no unique instructions file).
+// True when both skills and instructions are auto-covered
+// (SharedSkillsDir && NativeInstructions).
 func NeedsNoTracking(name string) bool {
 	a, ok := AllAgents[name]
-	return ok && a.SkillsDir == ".agents/skills" &&
-		(a.InstructionsFile == "" || a.InstructionsFile == "AGENTS.md")
+	return ok && a.SharedSkillsDir && a.NativeInstructions
 }
 
 // GetSharedSkillsDirAgents returns agents that use .agents/skills and are
@@ -506,7 +658,7 @@ func NeedsNoTracking(name string) bool {
 func GetSharedSkillsDirAgents() []string {
 	var result []string
 	for name, a := range AllAgents {
-		if a.SkillsDir == ".agents/skills" && a.AlwaysIncluded {
+		if a.SharedSkillsDir && a.AlwaysIncluded {
 			result = append(result, name)
 		}
 	}
@@ -514,11 +666,11 @@ func GetSharedSkillsDirAgents() []string {
 }
 
 // GetUniqueSkillsDirAgents returns agents with their own dedicated skills
-// directory (not .agents/skills). These always need explicit configuration.
+// directory. These always need explicit configuration.
 func GetUniqueSkillsDirAgents() []string {
 	var result []string
 	for name, a := range AllAgents {
-		if a.SkillsDir != ".agents/skills" {
+		if !a.SharedSkillsDir {
 			result = append(result, name)
 		}
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -24,7 +24,10 @@ type AgentConfig struct {
 	DisplayName     string
 	SkillsDir       string // relative, project-level skills directory path
 	GlobalSkillsDir string // absolute, user-level path (empty = global not supported)
-	AlwaysIncluded  bool   // show as locked/always-included in the agent picker
+	// ExcludeFromPicker, when true, hides this agent from the locked section of
+	// the agent picker in `mdm skills add`. Only a small handful of shared-dir
+	// agents (replit, universal) are excluded; all others are shown by default.
+	ExcludeFromPicker bool
 
 	// InstructionsFile is the project-root path to this agent's instruction
 	// file (e.g. "CLAUDE.md", ".cursorrules"). Empty means no instruction file.
@@ -107,7 +110,6 @@ func init() {
 			DisplayName:        "Amp",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(configHome, "agents/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   "AMP.md",
 			SharedSkillsDir:    true,
 			NativeInstructions: false,
@@ -118,7 +120,6 @@ func init() {
 			DisplayName:        "Cline",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".agents/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   ".clinerules",
 			SharedSkillsDir:    true,
 			NativeInstructions: false,
@@ -129,7 +130,6 @@ func init() {
 			DisplayName:        "Cursor",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".cursor/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   ".cursorrules",
 			SharedSkillsDir:    true,
 			NativeInstructions: false,
@@ -140,7 +140,6 @@ func init() {
 			DisplayName:        "Gemini CLI",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".gemini/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   "GEMINI.md",
 			SharedSkillsDir:    true,
 			NativeInstructions: false,
@@ -151,7 +150,6 @@ func init() {
 			DisplayName:        "GitHub Copilot",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".copilot/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   ".github/copilot-instructions.md",
 			SharedSkillsDir:    true,
 			NativeInstructions: false,
@@ -170,7 +168,6 @@ func init() {
 			DisplayName:        "Antigravity",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".gemini/antigravity/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".gemini/antigravity")) },
@@ -180,7 +177,6 @@ func init() {
 			DisplayName:        "Codex",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(codexHome, "skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   "AGENTS.md",
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
@@ -191,7 +187,6 @@ func init() {
 			DisplayName:        "Deep Agents",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".deepagents/agent/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".deepagents")) },
@@ -201,7 +196,6 @@ func init() {
 			DisplayName:        "Firebender",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".firebender/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".firebender")) },
@@ -211,7 +205,6 @@ func init() {
 			DisplayName:        "Kimi Code CLI",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".config/agents/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kimi")) },
@@ -221,7 +214,6 @@ func init() {
 			DisplayName:        "OpenCode",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(configHome, "opencode/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   "AGENTS.md",
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
@@ -232,7 +224,7 @@ func init() {
 			DisplayName:        "Replit",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(configHome, "agents/skills"),
-			AlwaysIncluded:     false,
+			ExcludeFromPicker:  true,
 			InstructionsFile:   "AGENTS.md",
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
@@ -246,7 +238,7 @@ func init() {
 			DisplayName:        "Universal",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(configHome, "agents/skills"),
-			AlwaysIncluded:     false,
+			ExcludeFromPicker:  true,
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return false },
@@ -256,7 +248,6 @@ func init() {
 			DisplayName:        "Warp",
 			SkillsDir:          ".agents/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".agents/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    true,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".warp")) },
@@ -273,7 +264,6 @@ func init() {
 			DisplayName:        "Claude Code",
 			SkillsDir:          ".claude/skills",
 			GlobalSkillsDir:    filepath.Join(claudeHome, "skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   "CLAUDE.md",
 			SharedSkillsDir:    false,
 			NativeInstructions: false,
@@ -284,7 +274,6 @@ func init() {
 			DisplayName:        "Roo Code",
 			SkillsDir:          ".roo/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".roo/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   ".roorules",
 			SharedSkillsDir:    false,
 			NativeInstructions: false,
@@ -295,7 +284,6 @@ func init() {
 			DisplayName:        "Windsurf",
 			SkillsDir:          ".windsurf/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".codeium/windsurf/skills"),
-			AlwaysIncluded:     true,
 			InstructionsFile:   ".windsurfrules",
 			SharedSkillsDir:    false,
 			NativeInstructions: false,
@@ -314,7 +302,6 @@ func init() {
 			DisplayName:        "AdaL",
 			SkillsDir:          ".adal/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".adal/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".adal")) },
@@ -324,7 +311,6 @@ func init() {
 			DisplayName:        "Augment",
 			SkillsDir:          ".augment/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".augment/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".augment")) },
@@ -334,7 +320,6 @@ func init() {
 			DisplayName:        "IBM Bob",
 			SkillsDir:          ".bob/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".bob/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".bob")) },
@@ -344,7 +329,6 @@ func init() {
 			DisplayName:        "CodeBuddy",
 			SkillsDir:          ".codebuddy/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".codebuddy/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled: func() bool {
@@ -357,7 +341,6 @@ func init() {
 			DisplayName:        "Command Code",
 			SkillsDir:          ".commandcode/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".commandcode/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".commandcode")) },
@@ -367,7 +350,6 @@ func init() {
 			DisplayName:        "Continue",
 			SkillsDir:          ".continue/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".continue/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled: func() bool {
@@ -380,7 +362,6 @@ func init() {
 			DisplayName:        "Cortex Code",
 			SkillsDir:          ".cortex/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".snowflake/cortex/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".snowflake/cortex")) },
@@ -390,7 +371,6 @@ func init() {
 			DisplayName:        "Crush",
 			SkillsDir:          ".crush/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".config/crush/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".config/crush")) },
@@ -400,7 +380,6 @@ func init() {
 			DisplayName:        "Droid",
 			SkillsDir:          ".factory/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".factory/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".factory")) },
@@ -410,7 +389,6 @@ func init() {
 			DisplayName:        "Goose",
 			SkillsDir:          ".goose/skills",
 			GlobalSkillsDir:    filepath.Join(configHome, "goose/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(configHome, "goose")) },
@@ -420,7 +398,6 @@ func init() {
 			DisplayName:        "iFlow CLI",
 			SkillsDir:          ".iflow/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".iflow/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".iflow")) },
@@ -430,7 +407,6 @@ func init() {
 			DisplayName:        "Junie",
 			SkillsDir:          ".junie/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".junie/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".junie")) },
@@ -440,7 +416,6 @@ func init() {
 			DisplayName:        "Kilo Code",
 			SkillsDir:          ".kilocode/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".kilocode/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kilocode")) },
@@ -450,7 +425,6 @@ func init() {
 			DisplayName:        "Kiro CLI",
 			SkillsDir:          ".kiro/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".kiro/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kiro")) },
@@ -460,7 +434,6 @@ func init() {
 			DisplayName:        "Kode",
 			SkillsDir:          ".kode/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".kode/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".kode")) },
@@ -470,7 +443,6 @@ func init() {
 			DisplayName:        "MCPJam",
 			SkillsDir:          ".mcpjam/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".mcpjam/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".mcpjam")) },
@@ -480,7 +452,6 @@ func init() {
 			DisplayName:        "Mistral Vibe",
 			SkillsDir:          ".vibe/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".vibe/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".vibe")) },
@@ -490,7 +461,6 @@ func init() {
 			DisplayName:        "Mux",
 			SkillsDir:          ".mux/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".mux/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".mux")) },
@@ -500,7 +470,6 @@ func init() {
 			DisplayName:        "Neovate",
 			SkillsDir:          ".neovate/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".neovate/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".neovate")) },
@@ -510,7 +479,6 @@ func init() {
 			DisplayName:        "OpenClaw",
 			SkillsDir:          "skills",
 			GlobalSkillsDir:    getOpenClawGlobalSkillsDir(),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled: func() bool {
@@ -524,7 +492,6 @@ func init() {
 			DisplayName:        "OpenHands",
 			SkillsDir:          ".openhands/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".openhands/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".openhands")) },
@@ -534,7 +501,6 @@ func init() {
 			DisplayName:        "Pi",
 			SkillsDir:          ".pi/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".pi/agent/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".pi/agent")) },
@@ -544,7 +510,6 @@ func init() {
 			DisplayName:        "Pochi",
 			SkillsDir:          ".pochi/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".pochi/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".pochi")) },
@@ -554,7 +519,6 @@ func init() {
 			DisplayName:        "Qoder",
 			SkillsDir:          ".qoder/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".qoder/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".qoder")) },
@@ -564,7 +528,6 @@ func init() {
 			DisplayName:        "Qwen Code",
 			SkillsDir:          ".qwen/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".qwen/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".qwen")) },
@@ -574,7 +537,6 @@ func init() {
 			DisplayName:        "Trae",
 			SkillsDir:          ".trae/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".trae/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".trae")) },
@@ -584,7 +546,6 @@ func init() {
 			DisplayName:        "Trae CN",
 			SkillsDir:          ".trae/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".trae-cn/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".trae-cn")) },
@@ -594,7 +555,6 @@ func init() {
 			DisplayName:        "Zencoder",
 			SkillsDir:          ".zencoder/skills",
 			GlobalSkillsDir:    filepath.Join(home, ".zencoder/skills"),
-			AlwaysIncluded:     true,
 			SharedSkillsDir:    false,
 			NativeInstructions: true,
 			DetectInstalled:    func() bool { return pathExists(filepath.Join(home, ".zencoder")) },
@@ -639,12 +599,6 @@ func UsesSharedSkillsDir(name string) bool {
 	return ok && a.SharedSkillsDir
 }
 
-// UsesAgentsMD reports whether the agent reads instructions from AGENTS.md.
-func UsesAgentsMD(name string) bool {
-	a, ok := AllAgents[name]
-	return ok && a.InstructionsFile == "AGENTS.md"
-}
-
 // NeedsNoTracking reports whether an agent requires no entry in configuredAgents.
 // True when both skills and instructions are auto-covered
 // (SharedSkillsDir && NativeInstructions).
@@ -654,11 +608,11 @@ func NeedsNoTracking(name string) bool {
 }
 
 // GetSharedSkillsDirAgents returns agents that use .agents/skills and are
-// marked AlwaysIncluded (i.e. shown as locked in the agent picker).
+// shown in the locked section of the agent picker (ExcludeFromPicker == false).
 func GetSharedSkillsDirAgents() []string {
 	var result []string
 	for name, a := range AllAgents {
-		if a.SharedSkillsDir && a.AlwaysIncluded {
+		if a.SharedSkillsDir && !a.ExcludeFromPicker {
 			result = append(result, name)
 		}
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const Version = "1.3.0"
+const Version = "1.3.1"
 const AppName = "mdm"
 
 // IsNewer reports whether latest is strictly greater than current (semver strings, "v" prefix optional).


### PR DESCRIPTION
When `mdm agents add <agent>` is called (interactively or with named
args), the command now runs two extra steps after persisting the
configured-agents list:

1. **Rules linking** — if AGENTS.md already exists as a real file in
   the project directory, each newly-added agent's instruction file
   (.windsurfrules, .cursorrules, CLAUDE.md, etc.) is symlinked to it
   automatically, matching the behaviour of `mdm rules link`.

2. **Skill back-fill** — every skill recorded in the project or global
   lock file is linked into the new agent's skills directory (symlink,
   with copy as fallback). Agents that share the `.agents/skills`
   canonical directory are skipped because they already have access to
   every installed skill automatically.

New helpers:
- commands/installer.go: linkInstalledSkillToAgent
- commands/agents.go: runAgentSetup, linkNewAgentRules,
  installLockedSkillsForAgents, agentsNeedingSkillLinks,
  collectSkillLinkSpecs, skillLinkSpec

pickAndSaveAgents now returns the selected agent names so the
interactive path can also call runAgentSetup.

https://claude.ai/code/session_01Gzssb5TuXjVt5pme1UGYWi