### PR TITLE
fix(installer): detect actual default branch instead of assuming main

### DIFF
--- a/commands/add.go
+++ b/commands/add.go
@@ -409,7 +409,7 @@ func runAddGitOrHub(parsed source.ParsedSource, opts AddOptions, cwd, sourceInpu
 	// Build lock entry
 	lockRef := ref
 	if lockRef == "" {
-		lockRef = "main"
+		lockRef = git.DefaultBranch(parsed.URL)
 	}
 	commitSHA, _ := git.GetLocalCommitSHA(tmpDir)
 	baseLockEntry := lock.SkillLockEntry{

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -101,6 +101,33 @@ func GetLocalCommitSHA(dir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// DefaultBranch returns the default branch name of a remote git repository by running
+// "git ls-remote --symref <url> HEAD" and parsing the symbolic ref line.
+// Falls back to "main" if the default branch cannot be determined.
+func DefaultBranch(gitURL string) string {
+	cmd := exec.Command("git", "ls-remote", "--symref", gitURL, "HEAD")
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_LFS_SKIP_SMUDGE=1",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return "main"
+	}
+	// Output format: "ref: refs/heads/<branch>\tHEAD\n<sha>\tHEAD\n"
+	const prefix = "ref: refs/heads/"
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			branch := strings.TrimPrefix(line, prefix)
+			branch = strings.Fields(branch)[0]
+			if branch != "" {
+				return branch
+			}
+		}
+	}
+	return "main"
+}
+
 // FetchRemoteCommitSHA fetches the commit SHA for the given ref on a remote git URL using
 // "git ls-remote", which works for any git host (GitHub, GitLab, Bitbucket, self-hosted)
 // without performing a full clone.  If ref is empty it resolves HEAD.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const Version = "1.5.4"
+const Version = "1.5.5"
 const AppName = "mdm"
 
 // IsNewer reports whether latest is strictly greater than current (semver strings, "v" prefix optional).

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -3,7 +3,7 @@
   "skills": {
     "go-report-card": {
       "source": "sethcarney/custom-plugins",
-      "ref": "main",
+      "ref": "master",
       "sourceType": "github"
     }
   },


### PR DESCRIPTION
Uses git ls-remote --symref to resolve the symbolic HEAD ref before
storing it in the lock entry, so repos whose default branch is master
(or any other name) update correctly with mdm skills update.

Closes #60

https://claude.ai/code/session_01Rn4QWGcyTyMyY3Sd1vg3EC