### PR TITLE
fix(ci): remove deprecated cosign flags and add signing retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,15 +76,9 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Sign binaries
+      - name: Sign checksums
         if: steps.check.outputs.exists == 'false'
-        run: |
-          for f in dist/mdm-linux-x64 dist/mdm-linux-arm64 dist/mdm-macos-x64 dist/mdm-macos-arm64 dist/mdm-windows-x64.exe; do
-            for attempt in 1 2 3; do
-              cosign sign-blob --yes "$f" --bundle "${f}.bundle" && break
-              [ "$attempt" -lt 3 ] && sleep $((attempt * 4))
-            done
-          done
+        run: cosign sign-blob --yes dist/sha256sums.txt --bundle dist/sha256sums.txt.bundle
 
       - name: Create GitHub Release
         if: steps.check.outputs.exists == 'false'
@@ -97,12 +91,8 @@ jobs:
             dist/mdm-macos-x64 \
             dist/mdm-macos-arm64 \
             dist/mdm-windows-x64.exe \
-            dist/mdm-linux-x64.bundle \
-            dist/mdm-linux-arm64.bundle \
-            dist/mdm-macos-x64.bundle \
-            dist/mdm-macos-arm64.bundle \
-            dist/mdm-windows-x64.exe.bundle \
-            dist/sha256sums.txt
+            dist/sha256sums.txt \
+            dist/sha256sums.txt.bundle
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,15 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Sign checksums
+      - name: Sign binaries
         if: steps.check.outputs.exists == 'false'
-        run: cosign sign-blob --yes dist/sha256sums.txt --bundle dist/sha256sums.txt.bundle
+        run: |
+          for f in dist/mdm-linux-x64 dist/mdm-linux-arm64 dist/mdm-macos-x64 dist/mdm-macos-arm64 dist/mdm-windows-x64.exe; do
+            cosign sign-blob --yes "$f" \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem"
+            sleep 5
+          done
 
       - name: Create GitHub Release
         if: steps.check.outputs.exists == 'false'
@@ -91,8 +97,17 @@ jobs:
             dist/mdm-macos-x64 \
             dist/mdm-macos-arm64 \
             dist/mdm-windows-x64.exe \
-            dist/sha256sums.txt \
-            dist/sha256sums.txt.bundle
+            dist/mdm-linux-x64.sig \
+            dist/mdm-linux-x64.pem \
+            dist/mdm-linux-arm64.sig \
+            dist/mdm-linux-arm64.pem \
+            dist/mdm-macos-x64.sig \
+            dist/mdm-macos-x64.pem \
+            dist/mdm-macos-arm64.sig \
+            dist/mdm-macos-arm64.pem \
+            dist/mdm-windows-x64.exe.sig \
+            dist/mdm-windows-x64.exe.pem \
+            dist/sha256sums.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,10 +80,10 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         run: |
           for f in dist/mdm-linux-x64 dist/mdm-linux-arm64 dist/mdm-macos-x64 dist/mdm-macos-arm64 dist/mdm-windows-x64.exe; do
-            cosign sign-blob --yes "$f" \
-              --bundle "${f}.bundle" \
-              --output-signature "${f}.sig" \
-              --output-certificate "${f}.pem"
+            for attempt in 1 2 3; do
+              cosign sign-blob --yes "$f" --bundle "${f}.bundle" && break
+              [ "$attempt" -lt 3 ] && sleep $((attempt * 4))
+            done
           done
 
       - name: Create GitHub Release
@@ -97,16 +97,6 @@ jobs:
             dist/mdm-macos-x64 \
             dist/mdm-macos-arm64 \
             dist/mdm-windows-x64.exe \
-            dist/mdm-linux-x64.sig \
-            dist/mdm-linux-x64.pem \
-            dist/mdm-linux-arm64.sig \
-            dist/mdm-linux-arm64.pem \
-            dist/mdm-macos-x64.sig \
-            dist/mdm-macos-x64.pem \
-            dist/mdm-macos-arm64.sig \
-            dist/mdm-macos-arm64.pem \
-            dist/mdm-windows-x64.exe.sig \
-            dist/mdm-windows-x64.exe.pem \
             dist/mdm-linux-x64.bundle \
             dist/mdm-linux-arm64.bundle \
             dist/mdm-macos-x64.bundle \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,6 @@ jobs:
             cosign sign-blob --yes "$f" \
               --output-signature "${f}.sig" \
               --output-certificate "${f}.pem"
-            sleep 5
           done
 
       - name: Create GitHub Release


### PR DESCRIPTION
--output-signature and --output-certificate are deprecated in newer
cosign versions and silently ignored when --bundle is used. Remove them
and drop the now-absent .sig/.pem artifacts from the release upload.

Add a 3-attempt retry loop (backoff: 4s, 8s) around each cosign
sign-blob call to handle transient stream errors like the INTERNAL_ERROR
seen on mdm-linux-arm64.

https://claude.ai/code/session_01DbD9AZa6rmkr9SjRVT1KLW