### PR TITLE
fix(ci): use cosign new bundle format and extract .sig for scorecard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,8 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         run: |
           for f in dist/mdm-linux-x64 dist/mdm-linux-arm64 dist/mdm-macos-x64 dist/mdm-macos-arm64 dist/mdm-windows-x64.exe; do
-            cosign sign-blob --yes "$f" \
-              --output-signature "${f}.sig" \
-              --output-certificate "${f}.pem"
+            cosign sign-blob --yes "$f" --bundle "${f}.bundle"
+            jq -r '.messageSignature.signature // .base64Signature' "${f}.bundle" > "${f}.sig"
           done
 
       - name: Create GitHub Release
@@ -96,16 +95,16 @@ jobs:
             dist/mdm-macos-x64 \
             dist/mdm-macos-arm64 \
             dist/mdm-windows-x64.exe \
+            dist/mdm-linux-x64.bundle \
+            dist/mdm-linux-arm64.bundle \
+            dist/mdm-macos-x64.bundle \
+            dist/mdm-macos-arm64.bundle \
+            dist/mdm-windows-x64.exe.bundle \
             dist/mdm-linux-x64.sig \
-            dist/mdm-linux-x64.pem \
             dist/mdm-linux-arm64.sig \
-            dist/mdm-linux-arm64.pem \
             dist/mdm-macos-x64.sig \
-            dist/mdm-macos-x64.pem \
             dist/mdm-macos-arm64.sig \
-            dist/mdm-macos-arm64.pem \
             dist/mdm-windows-x64.exe.sig \
-            dist/mdm-windows-x64.exe.pem \
             dist/sha256sums.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Recent cosign versions require `--bundle <path>` because the new bundle format is mandatory. Without it, signing fails with:

```
Error: signing dist/mdm-linux-x64: create bundle file: open : no such file or directory
```

The deprecated `--output-signature` / `--output-certificate` flags are silently ignored under the new bundle format, so the previous workflow produced no signature files and the release upload step would have failed even if signing had worked.

## What changed

- Sign each binary into its own `.bundle` — the industry-standard cosign artifact for keyless verification (`cosign verify-blob --bundle <path> --certificate-identity ... --certificate-oidc-issuer ...`).
- Extract the detached signature from the bundle JSON into `<binary>.sig` so the OpenSSF Scorecard `signed-releases` probe continues to detect a signature alongside each binary (the probe scans for `.sig` / `.asc` / `.sigstore` / `.intoto.jsonl`).
- Drop `.pem` files — the certificate is already inside the bundle, and Scorecard doesn't read `.pem`. Users verifying with cosign use the bundle directly.

## Why this preserves the Scorecard score

Historical releases (v1.1.5 → v1.5.5) had Scorecard's `signed-releases` probe reporting:

```
Info: signed release artifact: mdm-linux-arm64.sig: ...
Info: provenance for release artifact: multiple.intoto.jsonl: ...
```

This PR keeps both signals intact:
- `.sig` files alongside each binary (extracted from the bundle).
- SLSA provenance (`multiple.intoto.jsonl`) — unchanged, still produced by the existing `provenance` job.

## Test plan

- [ ] Push to main triggers the release workflow and it completes without error.
- [ ] The published GitHub release contains five `.bundle` and five `.sig` files alongside the binaries plus `sha256sums.txt`.
- [ ] `cosign verify-blob --bundle mdm-linux-x64.bundle --certificate-identity-regexp 'https://github.com/sethcarney/mdm/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com mdm-linux-x64` succeeds.
- [ ] On the next Scorecard run, `signed-releases` continues to report `.sig` artifacts and `multiple.intoto.jsonl` provenance per release.

https://claude.ai/code/session_01DbD9AZa6rmkr9SjRVT1KLW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD9AZa6rmkr9SjRVT1KLW)_