### PR TITLE
ci: migrate release pipeline to GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # GoReleaser needs full history for changelog and validation
 
       - name: Get version
         id: version
@@ -50,64 +52,36 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Generate Windows resource (version info + committed icon)
-        if: steps.check.outputs.exists == 'false'
-        run: make syso
-
-      - name: Build binaries
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          mkdir -p dist
-          GOOS=linux   GOARCH=amd64 go build -ldflags="-s -w" -o dist/mdm-linux-x64
-          GOOS=linux   GOARCH=arm64 go build -ldflags="-s -w" -o dist/mdm-linux-arm64
-          GOOS=darwin  GOARCH=amd64 go build -ldflags="-s -w" -o dist/mdm-macos-x64
-          GOOS=darwin  GOARCH=arm64 go build -ldflags="-s -w" -o dist/mdm-macos-arm64
-          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/mdm-windows-x64.exe
-
-      - name: Generate checksums
-        id: hash
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          cd dist
-          sha256sum mdm-linux-x64 mdm-linux-arm64 mdm-macos-x64 mdm-macos-arm64 mdm-windows-x64.exe > sha256sums.txt
-          echo "hashes=$(sha256sum mdm-linux-x64 mdm-linux-arm64 mdm-macos-x64 mdm-macos-arm64 mdm-windows-x64.exe | base64 -w0)" >> $GITHUB_OUTPUT
-
       - name: Install cosign
         if: steps.check.outputs.exists == 'false'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.5.3'
 
-      - name: Sign binaries
+      - name: Install Syft (for SBOM generation)
+        if: steps.check.outputs.exists == 'false'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Create release tag
         if: steps.check.outputs.exists == 'false'
         run: |
-          for f in dist/mdm-linux-x64 dist/mdm-linux-arm64 dist/mdm-macos-x64 dist/mdm-macos-arm64 dist/mdm-windows-x64.exe; do
-            cosign sign-blob --yes "$f" --bundle "${f}.bundle"
-            jq -r '.messageSignature.signature // .base64Signature' "${f}.bundle" > "${f}.sig"
-          done
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
 
-      - name: Create GitHub Release
+      - name: Run GoReleaser
         if: steps.check.outputs.exists == 'false'
-        run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
-            --generate-notes \
-            dist/mdm-linux-x64 \
-            dist/mdm-linux-arm64 \
-            dist/mdm-macos-x64 \
-            dist/mdm-macos-arm64 \
-            dist/mdm-windows-x64.exe \
-            dist/mdm-linux-x64.bundle \
-            dist/mdm-linux-arm64.bundle \
-            dist/mdm-macos-x64.bundle \
-            dist/mdm-macos-arm64.bundle \
-            dist/mdm-windows-x64.exe.bundle \
-            dist/mdm-linux-x64.sig \
-            dist/mdm-linux-arm64.sig \
-            dist/mdm-macos-x64.sig \
-            dist/mdm-macos-arm64.sig \
-            dist/mdm-windows-x64.exe.sig \
-            dist/sha256sums.txt
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          distribution: goreleaser
+          version: 'v2.15.4'
+          args: release --clean
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute hashes for SLSA provenance
+        id: hash
+        if: steps.check.outputs.exists == 'false'
+        run: echo "hashes=$(base64 -w0 < dist/sha256sums.txt)" >> $GITHUB_OUTPUT
 
   provenance:
     needs: [ release ]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+#
+# GoReleaser config for mdm.
+# https://goreleaser.com
+
+version: 2
+
+project_name: mdm
+
+before:
+  hooks:
+    - go mod tidy
+    # generate Windows version-info + icon resource so the windows build picks it up
+    - make syso
+
+builds:
+  - id: mdm
+    main: .
+    binary: mdm
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+# bare-binary release artifacts named to match the historical scheme:
+#   mdm-linux-x64, mdm-linux-arm64, mdm-macos-x64, mdm-macos-arm64, mdm-windows-x64.exe
+archives:
+  - id: mdm
+    formats: [binary]
+    name_template: 'mdm-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ if eq .Arch "amd64" }}x64{{ else }}{{ .Arch }}{{ end }}'
+
+# self-update reads sha256sums.txt by name, so keep that filename
+checksum:
+  name_template: "sha256sums.txt"
+  algorithm: sha256
+
+sboms:
+  - artifacts: archive
+
+# sign the checksum manifest once with keyless cosign; the bundle is
+# named .sigstore.json which the OpenSSF Scorecard signed-releases
+# probe recognizes natively (ossf/scorecard#3772).
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+
+release:
+  github:
+    owner: sethcarney
+    name: mdm
+  mode: keep-existing
+  draft: false

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const Version = "1.5.6"
+const Version = "1.5.7"
 const AppName = "mdm"
 
 // IsNewer reports whether latest is strictly greater than current (semver strings, "v" prefix optional).


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `release.yml` build / sign / upload pipeline with [GoReleaser](https://goreleaser.com), the de-facto-standard release tool for Go projects.

## Motivation

Recent cosign behavior changes broke the manual signing loop twice in quick succession (PRs #67 and #71). GoReleaser's maintainers track upstream cosign API churn for us — they already shipped a [cosign v3 upgrade guide](https://goreleaser.com/blog/cosign-v3/) — so future cosign churn becomes their problem, not ours.

This PR also adds per-binary SBOMs (via Syft), which is a new supply-chain signal we didn't have before, and drops ~70 lines of bespoke shell from `release.yml`.

## What changes

| | Before | After |
|---|---|---|
| Build | manual `GOOS=... GOARCH=... go build` × 5 | GoReleaser `builds` block |
| Checksum | manual `sha256sum` | GoReleaser `checksum` block (filename `sha256sums.txt` preserved) |
| Signing | manual `cosign sign-blob` loop + `jq` extract | GoReleaser `signs` block, signs `sha256sums.txt` once |
| SBOM | none | Syft generates per-binary `.sbom.json` |
| Upload | manual `gh release create` with explicit asset list | GoReleaser handles upload |
| SLSA provenance | unchanged (`slsa-github-generator`) | unchanged |

## Preserves existing contracts

- **Binary names** — `mdm-linux-x64`, `mdm-linux-arm64`, `mdm-macos-x64`, `mdm-macos-arm64`, `mdm-windows-x64.exe` (matches current naming).
- **Checksum filename** — `sha256sums.txt` (the `commands/selfupdate.go` self-update path looks for this name).
- **Version source** — `internal/version/version.go` (still read at workflow time).
- **Skip-if-release-exists** — preserved.
- **SLSA provenance** — `multiple.intoto.jsonl` still generated by the `provenance` job.

## OpenSSF Scorecard

The signature artifact is now `sha256sums.txt.sigstore.json` instead of per-binary `.sig` files. The `.sigstore.json` extension is recognized natively by Scorecard's `signed-releases` probe — see [ossf/scorecard#3772](https://github.com/ossf/scorecard/pull/3772) (merged Jan 2024). Combined with the existing SLSA `.intoto.jsonl` provenance, the score should be maintained or improved.

## Pinned dependencies

All actions pinned by commit SHA with version comment; binary tools pinned to explicit versions:

| Tool | Version |
|---|---|
| `goreleaser/goreleaser-action` | `v7.2.1` (SHA `1a80836c`) |
| `goreleaser` binary | `v2.15.4` |
| `sigstore/cosign-installer` | `v4.1.2` (SHA `6f9f1778`) |
| `cosign` binary | `v2.5.3` |
| `anchore/sbom-action/download-syft` | `v0.24.0` (SHA `e22c3899`) |

## Test plan

- [ ] Bump `internal/version/version.go` and merge to `main`.
- [ ] Release workflow completes; `dist/` contains 5 binaries, `sha256sums.txt`, `sha256sums.txt.sigstore.json`, 5 `.sbom.json` files.
- [ ] `cosign verify-blob --bundle sha256sums.txt.sigstore.json --certificate-identity-regexp 'https://github.com/sethcarney/mdm/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com sha256sums.txt` succeeds.
- [ ] `mdm upgrade` self-update path still verifies via `sha256sums.txt`.
- [ ] Next Scorecard run still shows `signed-releases` and SLSA provenance signals.

https://claude.ai/code/session_01DbD9AZa6rmkr9SjRVT1KLW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbD9AZa6rmkr9SjRVT1KLW)_