### PR TITLE
refactor(ci): switch release pipeline to tag-based releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
-    paths-ignore:
-      - "**/*.md"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Version to release (e.g. 1.0.0) — skips the duplicate check"
-        required: false
+    tags:
+      - 'v*'
 
 permissions: read-all
 
@@ -20,9 +14,7 @@ jobs:
       contents: write
       id-token: write # needed for OIDC keyless cosign signing
     outputs:
-      version: ${{ steps.version.outputs.version }}
       hashes: ${{ steps.hash.outputs.hashes }}
-      release_exists: ${{ steps.check.outputs.exists }}
 
     steps:
       - name: Checkout
@@ -30,46 +22,20 @@ jobs:
         with:
           fetch-depth: 0 # GoReleaser needs full history for changelog and validation
 
-      - name: Get version
-        id: version
-        run: echo "version=$(grep 'const Version' internal/version/version.go | grep -oP
-          '"\K[^"]+')" >> $GITHUB_OUTPUT
-
-      - name: Check if release already exists
-        id: check
-        run: |
-          if gh release view "v${{ steps.version.outputs.version }}" > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Go
-        if: steps.check.outputs.exists == 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Install cosign
-        if: steps.check.outputs.exists == 'false'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: 'v2.5.3'
 
       - name: Install Syft (for SBOM generation)
-        if: steps.check.outputs.exists == 'false'
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
-      - name: Create release tag
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
-
       - name: Run GoReleaser
-        if: steps.check.outputs.exists == 'false'
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           distribution: goreleaser
@@ -80,12 +46,10 @@ jobs:
 
       - name: Compute hashes for SLSA provenance
         id: hash
-        if: steps.check.outputs.exists == 'false'
         run: echo "hashes=$(base64 -w0 < dist/sha256sums.txt)" >> $GITHUB_OUTPUT
 
   provenance:
-    needs: [ release ]
-    if: needs.release.outputs.release_exists == 'false'
+    needs: [release]
     permissions:
       actions: read
       id-token: write
@@ -99,4 +63,4 @@ jobs:
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true
-      upload-tag-name: "v${{ needs.release.outputs.version }}"
+      upload-tag-name: "${{ github.ref_name }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w
+      - -s -w -X github.com/sethcarney/mdm/internal/version.Version={{.Version}}
     goos:
       - linux
       - darwin
@@ -68,5 +68,4 @@ release:
   github:
     owner: sethcarney
     name: mdm
-  mode: keep-existing
   draft: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,4 +199,13 @@ Right-click `mdm.exe` → Properties → Details to verify the icon and version 
 
 ## Release Process
 
-CI in `.github/workflows/release.yml` triggers on pushes to `main` (non-markdown files). It builds binaries for Linux/macOS/Windows (x64 + ARM64), then creates a GitHub release. Version is read from `internal/version/version.go` — bump it there before merging to main.
+CI in `.github/workflows/release.yml` triggers on **tag pushes** matching `v*`. To release:
+
+```bash
+git tag v1.5.8
+git push origin v1.5.8
+```
+
+GoReleaser builds binaries for Linux/macOS/Windows (x64 + ARM64), creates a GitHub release, and injects the tag as the version via ldflags. `internal/version/version.go` holds a `"dev"` fallback for `go install` users — do not bump it for releases, the tag is the source of truth.
+
+Pre-releases work the same way: push a tag like `v1.6.0-rc.1` and GoReleaser marks the GitHub release as a prerelease automatically. `mdm upgrade` skips prereleases because GitHub's `/releases/latest` API excludes them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ mdm
     ├── git/             # Shallow git clone; branch/ref handling
     ├── blob/            # GitHub API tree/blob queries for skill discovery
     ├── ui/              # ANSI color constants; Bubbletea spinner
-    └── version/         # Version constant (bump here for releases)
+    └── version/         # App name + dev fallback version (release tags override via ldflags)
 ```
 
 ### Key data flow

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const Version = "1.5.7"
+var Version = "dev" // overridden by ldflags at release build time
 const AppName = "mdm"
 
 // IsNewer reports whether latest is strictly greater than current (semver strings, "v" prefix optional).


### PR DESCRIPTION
- Workflow now triggers on `v*` tag pushes instead of push to main
- Removed version-reading, duplicate-check, and tag-creation steps
- Added ldflags version injection so the tag drives `mdm --version`
- Changed version.Version from const to var ("dev" fallback for go install)
- Dropped `mode: keep-existing` from goreleaser; GoReleaser owns the release
- Updated AGENTS.md release process docs

Closes #73

https://claude.ai/code/session_01GPe284hd6pYR2qstmhAKWh