### PR TITLE
Improve Windows version parsing to support GoReleaser tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,11 @@ icon:
 # Run this before building the Windows release binary.
 # Version is read automatically from internal/version/version.go.
 syso: assets/mdm.ico
-	$(eval VERSION := $(shell grep 'const Version' internal/version/version.go | sed 's/.*"\(.*\)".*/\1/'))
-	$(eval VMAJOR  := $(word 1,$(subst ., ,$(VERSION))))
-	$(eval VMINOR  := $(word 2,$(subst ., ,$(VERSION))))
-	$(eval VPATCH  := $(word 3,$(subst ., ,$(VERSION))))
+	$(eval _TAG    := $(or $(GORELEASER_CURRENT_TAG),$(shell grep 'Version =' internal/version/version.go | sed 's/.*"\(.*\)".*/\1/')))
+	$(eval _SEMVER := $(shell printf '%s' '$(_TAG)' | sed 's/^v//; s/-.*//' ))
+	$(eval VMAJOR  := $(shell printf '%s' '$(_SEMVER)' | cut -d. -f1 | grep -E '^[0-9]+$$' || echo 0))
+	$(eval VMINOR  := $(shell printf '%s' '$(_SEMVER)' | cut -d. -f2 | grep -E '^[0-9]+$$' || echo 0))
+	$(eval VPATCH  := $(shell printf '%s' '$(_SEMVER)' | cut -d. -f3 | grep -E '^[0-9]+$$' || echo 0))
 	go tool goversioninfo \
 	    -64 \
 	    -ver-major $(VMAJOR) -ver-minor $(VMINOR) -ver-patch $(VPATCH) -ver-build 0 \


### PR DESCRIPTION
## Summary
Updated the Makefile's `syso` target to improve version extraction for Windows binary metadata. The changes enable the build system to use GoReleaser's tag information when available, while maintaining backward compatibility with the internal version file.

## Key Changes
- Modified version extraction to prioritize `GORELEASER_CURRENT_TAG` environment variable over the hardcoded version in `internal/version/version.go`
- Implemented semantic versioning parsing that strips the leading 'v' prefix and removes pre-release/build metadata (e.g., `v1.2.3-rc1` → `1.2.3`)
- Enhanced version component extraction (major, minor, patch) with validation to ensure only numeric values are captured, defaulting to `0` for missing or invalid components
- Replaced simple string substitution with more robust `cut` and `grep` commands for reliable version parsing

## Implementation Details
- The new approach uses `printf` and `sed` to normalize the tag format before parsing
- Each version component is validated with a regex pattern (`^[0-9]+$$`) to ensure it contains only digits
- Fallback values of `0` are applied for any missing or invalid version components, ensuring the Windows version info is always valid
- This change enables seamless integration with GoReleaser workflows while preserving existing local build functionality

https://claude.ai/code/session_01GPe284hd6pYR2qstmhAKWh