### PR TITLE
Pass current tag to syso make target during release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ before:
   hooks:
     - go mod tidy
     # generate Windows version-info + icon resource so the windows build picks it up
-    - make syso
+    - make syso GORELEASER_CURRENT_TAG={{ .Tag }}
 
 builds:
   - id: mdm


### PR DESCRIPTION
## Summary
Updated the goreleaser configuration to pass the current release tag to the `make syso` command during the build process.

## Key Changes
- Modified `.goreleaser.yaml` to include `GORELEASER_CURRENT_TAG={{ .Tag }}` parameter when invoking `make syso`
- This allows the syso target to access the current release tag during Windows version-info and icon resource generation

## Implementation Details
The change enables the Windows build process to embed the correct version information by making the release tag available as an environment variable to the syso make target. This ensures that Windows executables built during release have accurate version metadata corresponding to the release tag.

https://claude.ai/code/session_01GPe284hd6pYR2qstmhAKWh