### PR TITLE
Replace make syso with direct goversioninfo command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,8 @@ before:
   hooks:
     - go mod tidy
     # generate Windows version-info + icon resource so the windows build picks it up
-    - make syso GORELEASER_CURRENT_TAG={{ .Tag }}
+    # .Major/.Minor/.Patch are GoReleaser-parsed integers; pre-release suffix already stripped
+    - go tool goversioninfo -64 -ver-major {{.Major}} -ver-minor {{.Minor}} -ver-patch {{.Patch}} -ver-build 0 -product-ver-major {{.Major}} -product-ver-minor {{.Minor}} -product-ver-patch {{.Patch}} -product-ver-build 0 -o resource_windows.syso assets/versioninfo.json
 
 builds:
   - id: mdm


### PR DESCRIPTION
## Summary
Replaced the `make syso` build hook with a direct `go tool goversioninfo` command in the GoReleaser configuration, eliminating the dependency on a Makefile target for Windows version resource generation.

## Key Changes
- Removed `make syso GORELEASER_CURRENT_TAG={{ .Tag }}` build hook
- Replaced with direct `goversioninfo` invocation using GoReleaser's parsed version components (`.Major`, `.Minor`, `.Patch`)
- Added clarifying comment explaining that version components are pre-parsed integers with pre-release suffixes already stripped
- Specifies explicit output file path (`resource_windows.syso`) and input configuration file (`assets/versioninfo.json`)

## Implementation Details
- Uses GoReleaser's built-in version parsing (`.Major`, `.Minor`, `.Patch`) instead of passing the raw tag
- Sets all version fields (major, minor, patch, build) explicitly with `0` for build numbers
- Maintains the same Windows resource generation functionality while making the build process more transparent and reducing Makefile coupling

https://claude.ai/code/session_01GPe284hd6pYR2qstmhAKWh