### PR TITLE
feat(find): add --source flag to list skills from remote sources

### DIFF
--- a/commands/find.go
+++ b/commands/find.go
@@ -7,12 +7,17 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/sethcarney/mdm/internal/blob"
+	"github.com/sethcarney/mdm/internal/git"
+	"github.com/sethcarney/mdm/internal/lock"
 	"github.com/sethcarney/mdm/internal/registry"
+	"github.com/sethcarney/mdm/internal/source"
 	"github.com/sethcarney/mdm/internal/ui"
 )
 
@@ -27,8 +32,15 @@ type FindSkillResult struct {
 	Repo        string `json:"repo,omitempty"`
 }
 
+// RemoteSkillEntry is the JSON shape returned by `skills find --source --json`.
+type RemoteSkillEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
 func buildFindCmd() *cobra.Command {
 	var jsonMode bool
+	var sourceFlag string
 	cmd := &cobra.Command{
 		Use:     "find [query]",
 		Short:   "Search the skills registry",
@@ -37,9 +49,14 @@ func buildFindCmd() *cobra.Command {
 
 %sExamples:%s
   mdm skills find typescript
-  mdm skills find git`, ansiBold, ansiReset),
+  mdm skills find git
+  mdm skills find --source owner/repo --json`, ansiBold, ansiReset),
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if sourceFlag != "" {
+				runFindSource(sourceFlag, jsonMode)
+				return
+			}
 			if jsonMode {
 				runFindJSON(args)
 				return
@@ -49,6 +66,7 @@ func buildFindCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&jsonMode, "json", false, "Output results as JSON without installing")
+	cmd.Flags().StringVar(&sourceFlag, "source", "", "List skills available at a remote source without installing")
 	return cmd
 }
 
@@ -141,6 +159,98 @@ func runFind(args []string) {
 	fmt.Println()
 	for _, i := range indices {
 		installFindResult(results[i])
+	}
+}
+
+func runFindSource(sourceInput string, jsonMode bool) {
+	parsed := source.ParseSource(sourceInput)
+	entries, err := fetchSourceSkillEntries(parsed, sourceInput)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to fetch skills: %v\n", err)
+		os.Exit(1)
+	}
+	if len(entries) == 0 {
+		if jsonMode {
+			fmt.Println("[]")
+		} else {
+			fmt.Fprintf(os.Stderr, "%sNo skills found at %s%s\n", ansiDim, sourceInput, ansiReset)
+		}
+		return
+	}
+	if jsonMode {
+		out, _ := json.MarshalIndent(entries, "", "  ")
+		fmt.Println(string(out))
+		return
+	}
+	fmt.Println()
+	options := make([]ui.UIOption, len(entries))
+	for i, s := range entries {
+		options[i] = ui.UIOption{Label: s.Name, Value: s.Name, Hint: s.Description}
+	}
+	indices, ok := ui.UiSearchMultiselect("Select skills to install", options, nil, nil, false)
+	if !ok || len(indices) == 0 {
+		return
+	}
+	var names []string
+	for _, i := range indices {
+		names = append(names, entries[i].Name)
+	}
+	fmt.Println()
+	runAdd(sourceInput, AddOptions{PreselectedSkills: names})
+}
+
+func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string) ([]RemoteSkillEntry, error) {
+	switch parsed.Type {
+	case source.SourceTypeWellKnown:
+		spin := ui.NewSpinner("Fetching skills...")
+		skills, err := registry.FetchAllWellKnownSkills(parsed.URL)
+		spin.Stop("")
+		if err != nil {
+			return nil, err
+		}
+		var entries []RemoteSkillEntry
+		for _, s := range skills {
+			entries = append(entries, RemoteSkillEntry{Name: s.Name, Description: s.Description})
+		}
+		return entries, nil
+	case source.SourceTypeLocal:
+		skills := discoverSkillsInDir(parsed.LocalPath, false, "")
+		var entries []RemoteSkillEntry
+		for _, s := range skills {
+			entries = append(entries, RemoteSkillEntry{Name: s.Name, Description: s.Description})
+		}
+		return entries, nil
+	case source.SourceTypeGitHub:
+		ownerRepo := source.GetOwnerRepo(parsed)
+		spin := ui.NewSpinner("Fetching skills...")
+		metas, err := blob.FetchRemoteSkillList(ownerRepo, parsed.Ref, parsed.Subpath, lock.GetGitHubToken())
+		spin.Stop("")
+		if err != nil {
+			return nil, err
+		}
+		var entries []RemoteSkillEntry
+		for _, m := range metas {
+			entries = append(entries, RemoteSkillEntry{Name: m.Name, Description: m.Description})
+		}
+		return entries, nil
+	default:
+		spin := ui.NewSpinner("Cloning " + parsed.URL + "...")
+		tmpDir, err := git.CloneRepo(parsed.URL, parsed.Ref)
+		spin.Stop("")
+		if err != nil {
+			return nil, err
+		}
+		defer git.CleanupTempDir(tmpDir)
+		searchRoot := tmpDir
+		if parsed.Subpath != "" {
+			searchRoot = filepath.Join(tmpDir, parsed.Subpath)
+		}
+		skills := discoverSkillsInDir(searchRoot, false, "")
+		var entries []RemoteSkillEntry
+		for _, s := range skills {
+			entries = append(entries, RemoteSkillEntry{Name: s.Name, Description: s.Description})
+		}
+		return entries, nil
 	}
 }
 

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -196,6 +196,48 @@ func fetchBlobSkillData(ctx context.Context, owner, repo, slug, branch, subpath,
 	return &BlobSkill{Skill: skill.Skill{Name: name, Description: desc, Version: version}, Files: dlResp.Files, SnapshotHash: dlResp.Hash, RepoPath: skillMdPath}
 }
 
+// RemoteSkillMeta holds the name and description of a skill discovered from a
+// remote SKILL.md without downloading full skill content.
+type RemoteSkillMeta struct {
+	Name        string
+	Description string
+}
+
+// FetchRemoteSkillList returns skill metadata from any public GitHub repo
+// without downloading full skill content. Unlike TryBlobInstall it has no
+// owner allowlist restriction because it performs no write operations.
+func FetchRemoteSkillList(ownerRepo, ref, subpath, token string) ([]*RemoteSkillMeta, error) {
+	var refPtr *string
+	if ref != "" {
+		refPtr = &ref
+	}
+	tree, err := FetchRepoTree(ownerRepo, refPtr, token)
+	if err != nil {
+		return nil, err
+	}
+	skillPaths := findSkillMdPaths(tree, subpath)
+	if len(skillPaths) == 0 {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var results []*RemoteSkillMeta
+	for _, p := range skillPaths {
+		body, ok := fetchSkillMDContent(ctx, ownerRepo, tree.Branch, p, token)
+		if !ok {
+			continue
+		}
+		data, _ := skill.ParseFrontmatter(string(body))
+		name, _ := data["name"].(string)
+		desc, _ := data["description"].(string)
+		if name == "" {
+			continue
+		}
+		results = append(results, &RemoteSkillMeta{Name: name, Description: desc})
+	}
+	return results, nil
+}
+
 func TryBlobInstall(ownerRepo string, opts struct {
 	Subpath         string
 	SkillFilter     string


### PR DESCRIPTION
## Summary

Adds a `--source` flag to `mdm skills find` that allows users to browse and install skills directly from a remote source (GitHub repo, GitLab, well-known registry, or local path) without querying the skills.sh registry.

## Key Changes

- **New `--source` flag**: Lists skills available at a remote source with optional `--json` output for scripting
- **Interactive skill selection**: When used without `--json`, displays a multi-select UI to choose which skills to install from the source
- **New `RemoteSkillEntry` type**: JSON-serializable struct for remote skill metadata (name and description)
- **New `runFindSource()` function**: Handles the `--source` workflow, fetching skill entries and delegating to `runAdd()` for installation
- **New `fetchSourceSkillEntries()` function**: Unified handler for fetching skill metadata from all source types:
  - Well-known registries (via `registry.FetchAllWellKnownSkills`)
  - Local directories (via `discoverSkillsInDir`)
  - GitHub repos (via `blob.FetchRemoteSkillList`)
  - Generic Git repos (clone, discover, cleanup)
- **New `FetchRemoteSkillList()` in blob.go**: GitHub API helper that fetches skill metadata from any public repo without downloading full skill content or requiring owner allowlist
- **New `RemoteSkillMeta` type in blob.go**: Holds name and description parsed from remote SKILL.md frontmatter

## Implementation Details

- The `--source` flag takes precedence over positional query arguments
- Supports all existing source formats: `owner/repo`, `owner/repo@ref`, `owner/repo/subpath`, URLs, and local paths
- Reuses existing `source.ParseSource()` and `git.CloneRepo()` infrastructure for consistent behavior
- Skill discovery respects subpath filtering when specified
- Temporary directories are properly cleaned up after cloning
- JSON output format matches the new `RemoteSkillEntry` schema for consistency

https://claude.ai/code/session_01UCDNrgnE9L12mwZyzbrU1T