### PR TITLE
fix(find): suppress spinner output in JSON mode

### DIFF
--- a/commands/find.go
+++ b/commands/find.go
@@ -164,7 +164,7 @@ func runFind(args []string) {
 
 func runFindSource(sourceInput string, jsonMode bool) {
 	parsed := source.ParseSource(sourceInput)
-	entries, err := fetchSourceSkillEntries(parsed, sourceInput)
+	entries, err := fetchSourceSkillEntries(parsed, sourceInput, jsonMode)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fetch skills: %v\n", err)
 		os.Exit(1)
@@ -199,12 +199,17 @@ func runFindSource(sourceInput string, jsonMode bool) {
 	runAdd(sourceInput, AddOptions{PreselectedSkills: names})
 }
 
-func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string) ([]RemoteSkillEntry, error) {
+func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string, jsonMode bool) ([]RemoteSkillEntry, error) {
 	switch parsed.Type {
 	case source.SourceTypeWellKnown:
-		spin := ui.NewSpinner("Fetching skills...")
+		var spin *ui.Spinner
+		if !jsonMode {
+			spin = ui.NewSpinner("Fetching skills...")
+		}
 		skills, err := registry.FetchAllWellKnownSkills(parsed.URL)
-		spin.Stop("")
+		if !jsonMode {
+			spin.Stop("")
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -222,9 +227,14 @@ func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string) ([]
 		return entries, nil
 	case source.SourceTypeGitHub:
 		ownerRepo := source.GetOwnerRepo(parsed)
-		spin := ui.NewSpinner("Fetching skills...")
+		var spin *ui.Spinner
+		if !jsonMode {
+			spin = ui.NewSpinner("Fetching skills...")
+		}
 		metas, err := blob.FetchRemoteSkillList(ownerRepo, parsed.Ref, parsed.Subpath, lock.GetGitHubToken())
-		spin.Stop("")
+		if !jsonMode {
+			spin.Stop("")
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -234,9 +244,14 @@ func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string) ([]
 		}
 		return entries, nil
 	default:
-		spin := ui.NewSpinner("Cloning " + parsed.URL + "...")
+		var spin *ui.Spinner
+		if !jsonMode {
+			spin = ui.NewSpinner("Cloning " + parsed.URL + "...")
+		}
 		tmpDir, err := git.CloneRepo(parsed.URL, parsed.Ref)
-		spin.Stop("")
+		if !jsonMode {
+			spin.Stop("")
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/commands/find.go
+++ b/commands/find.go
@@ -199,17 +199,26 @@ func runFindSource(sourceInput string, jsonMode bool) {
 	runAdd(sourceInput, AddOptions{PreselectedSkills: names})
 }
 
+func startSpinner(msg string, show bool) *ui.Spinner {
+	if show {
+		return ui.NewSpinner(msg)
+	}
+	return nil
+}
+
+func stopSpinner(s *ui.Spinner) {
+	if s != nil {
+		s.Stop("")
+	}
+}
+
 func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string, jsonMode bool) ([]RemoteSkillEntry, error) {
+	show := !jsonMode
 	switch parsed.Type {
 	case source.SourceTypeWellKnown:
-		var spin *ui.Spinner
-		if !jsonMode {
-			spin = ui.NewSpinner("Fetching skills...")
-		}
+		spin := startSpinner("Fetching skills...", show)
 		skills, err := registry.FetchAllWellKnownSkills(parsed.URL)
-		if !jsonMode {
-			spin.Stop("")
-		}
+		stopSpinner(spin)
 		if err != nil {
 			return nil, err
 		}
@@ -227,14 +236,9 @@ func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string, jso
 		return entries, nil
 	case source.SourceTypeGitHub:
 		ownerRepo := source.GetOwnerRepo(parsed)
-		var spin *ui.Spinner
-		if !jsonMode {
-			spin = ui.NewSpinner("Fetching skills...")
-		}
+		spin := startSpinner("Fetching skills...", show)
 		metas, err := blob.FetchRemoteSkillList(ownerRepo, parsed.Ref, parsed.Subpath, lock.GetGitHubToken())
-		if !jsonMode {
-			spin.Stop("")
-		}
+		stopSpinner(spin)
 		if err != nil {
 			return nil, err
 		}
@@ -244,14 +248,9 @@ func fetchSourceSkillEntries(parsed source.ParsedSource, sourceInput string, jso
 		}
 		return entries, nil
 	default:
-		var spin *ui.Spinner
-		if !jsonMode {
-			spin = ui.NewSpinner("Cloning " + parsed.URL + "...")
-		}
+		spin := startSpinner("Cloning "+parsed.URL+"...", show)
 		tmpDir, err := git.CloneRepo(parsed.URL, parsed.Ref)
-		if !jsonMode {
-			spin.Stop("")
-		}
+		stopSpinner(spin)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Suppress UI spinner output when `--json` flag is used in the `mdm skills find` command, ensuring clean JSON output without terminal control sequences.

## Changes

- Pass `jsonMode` flag to `fetchSourceSkillEntries()` function
- Conditionally create and stop spinners only when not in JSON mode across all three source type handlers:
  - Well-known registry sources
  - GitHub sources
  - Default/git clone sources

## Implementation Details

The spinner is now only instantiated and stopped when `jsonMode` is `false`. This prevents spinner terminal control sequences from polluting JSON output when users pipe results or parse the output programmatically.

https://claude.ai/code/session_01PXfANao6fXttcywbH8C6Pg