### PR TITLE
chore: bump Go toolchain to 1.26.4 to fix stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sethcarney/mdm
 
-go 1.26.3
+go 1.26.4
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
Resolves govulncheck failures in CI caused by two Go standard library
vulnerabilities present in go1.26.3:

- GO-2026-5039: net/textproto arbitrary inputs in errors without
  escaping (reached via internal/registry/osv.go)
- GO-2026-5037: crypto/x509 inefficient candidate hostname parsing
  (reached via internal/ui/ui.go and main.go)

Both are fixed in go1.26.4. CI uses go-version-file: go.mod, so bumping
the go directive is sufficient to unblock the dependency-update PRs whose
vulnerability-scan job was failing on these stdlib advisories.