### PR TITLE
Experimental: mdm knowledge for OKF consumption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,18 @@ mdm
 │   ├── init [name]                         # Scaffold a new SKILL.md in the current directory
 │   ├── install                             # Restore all skills from skills-lock.json (CI/onboarding)
 │   └── sync                                # Sync skills from node_modules into agent skill directories
+├── knowledge                               # [EXPERIMENTAL] Manage OKF knowledge bundles (hidden until enabled; see docs/experimental.md)
+│   ├── add <source>                        # Install an OKF bundle into ./knowledge/ and record it in knowledge-lock.json (alias: a)
+│   ├── remove [bundles...]                 # Remove bundles and their lock entries (aliases: rm, r)
+│   ├── list                                # List installed bundles (alias: ls)
+│   ├── update [bundles...]                 # Re-fetch bundles from their recorded source+ref
+│   ├── validate [path]                     # Check OKF conformance and link integrity (--json)
+│   ├── init [name]                         # Scaffold a minimal conformant bundle
+│   └── install                             # Restore all bundles from knowledge-lock.json (CI/onboarding)
+├── experimental                            # Manage experimental features (also: MDM_EXPERIMENTAL env var)
+│   ├── list                                # Show experimental features and their status (alias: ls)
+│   ├── enable <feature>                    # Persist an opt-in
+│   └── disable <feature>                   # Remove a persisted opt-in
 ├── agents                                  # Manage the configured agent list used as default install targets
 │   ├── list                                # Show configured agents for the current scope (alias: ls)
 │   ├── add [agents...]                     # Add agents to the configured list (interactive picker with no args)
@@ -108,13 +120,17 @@ mdm
 │   ├── selfupdate.go    # `mdm upgrade`: downloads and replaces the mdm binary from GitHub releases
 │   ├── uninstall.go     # `mdm uninstall`: removes the mdm binary from the system
 │   ├── hidden_scan.go   # Hidden-character pre-install scan shared by add/update
+│   ├── experimental.go  # `mdm experimental` group: list/enable/disable feature gates
+│   ├── knowledge*.go    # `mdm knowledge` group [EXPERIMENTAL]: OKF bundle add/list/remove/update/validate/init/install + doctor section
 │   └── doctor.go        # `mdm doctor`: checks skill health, symlinks, hashes, README presence, and markdown sizes
 ├── internal/
     ├── agent/           # AllAgents registry (45+ agents); skill dir paths; detection
     ├── skill/           # Skill discovery (SKILL.md parsing); frontmatter; filtering
+    ├── okf/             # [EXPERIMENTAL] OKF bundle parsing, discovery, validation, content hashing
+    ├── experimental/    # Named feature gates (MDM_EXPERIMENTAL env var + persisted opt-ins)
     ├── source/          # URL/path parsing into ParsedSource (GitHub, GitLab, local, well-known)
     ├── registry/        # Well-known registry fetching (.well-known/agent-skills standard)
-    ├── lock/            # skills-lock.json read/write; tracks hashes, versions, timestamps, configuredAgents
+    ├── lock/            # skills-lock.json + knowledge-lock.json read/write; tracks hashes, versions, timestamps, configuredAgents
     ├── git/             # Shallow git clone; branch/ref handling
     ├── blob/            # GitHub API tree/blob queries for skill discovery
     ├── security/        # markdownscan: hidden-character / prompt-smuggling detection

--- a/commands/doctor.go
+++ b/commands/doctor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sethcarney/mdm/internal/agent"
+	"github.com/sethcarney/mdm/internal/experimental"
 	"github.com/sethcarney/mdm/internal/lock"
 	"github.com/sethcarney/mdm/internal/skill"
 )
@@ -138,6 +139,7 @@ func runDoctor(opts DoctorOptions) {
 	var instrIssues []doctorIssue
 	var unlinkedRulesIssues []doctorIssue
 	var missingSkillLinkIssues []doctorIssue
+	var knowledgeIssues []doctorIssue
 	var mdIssues []doctorIssue
 	var mdTruncated bool
 
@@ -146,6 +148,9 @@ func runDoctor(opts DoctorOptions) {
 		instrIssues = checkInstructionFiles(cwd)
 		unlinkedRulesIssues = checkUnlinkedRulesAgents(cwd)
 		missingSkillLinkIssues = checkMissingAgentSkillLinks(cwd)
+		if experimental.Enabled(experimental.Knowledge) {
+			knowledgeIssues = checkKnowledgeBundles(cwd)
+		}
 		mdIssues, mdTruncated = checkProjectMarkdown(cwd, skipDirs, skipFiles)
 		if mdTruncated {
 			vlog(verboseFlag, "project markdown walk hit the %d-entry limit; results truncated", markdownWalkLimit)
@@ -160,7 +165,7 @@ func runDoctor(opts DoctorOptions) {
 		return results[i].Name < results[j].Name
 	})
 
-	printDoctorResults(results, instrIssues, unlinkedRulesIssues, missingSkillLinkIssues, mdIssues, mdTruncated, readmeIssue, checkProject, cwd)
+	printDoctorResults(results, instrIssues, unlinkedRulesIssues, missingSkillLinkIssues, knowledgeIssues, mdIssues, mdTruncated, readmeIssue, checkProject, cwd)
 }
 
 func buildProjectSkipPaths(cwd, canonicalBase string, skipDirs, skipFiles map[string]bool) {
@@ -523,7 +528,7 @@ func checkProjectMarkdown(cwd string, skipDirs map[string]bool, skipFiles map[st
 
 // ── Output ─────────────────────────────────────────────────────────────────────
 
-func printDoctorResults(results []doctorResult, instrIssues, unlinkedRulesIssues, missingSkillLinkIssues, mdIssues []doctorIssue, mdTruncated bool, readmeIssue *doctorIssue, scannedProject bool, cwd string) {
+func printDoctorResults(results []doctorResult, instrIssues, unlinkedRulesIssues, missingSkillLinkIssues, knowledgeIssues, mdIssues []doctorIssue, mdTruncated bool, readmeIssue *doctorIssue, scannedProject bool, cwd string) {
 	fmt.Println()
 
 	byScope := map[string][]doctorResult{}
@@ -562,6 +567,14 @@ func printDoctorResults(results []doctorResult, instrIssues, unlinkedRulesIssues
 	if len(missingSkillLinkIssues) > 0 {
 		fmt.Printf("%sSkill coverage:%s\n\n", ansiText, ansiReset)
 		e, w := printAndCountDoctorIssues(missingSkillLinkIssues)
+		totalErrors += e
+		totalWarnings += w
+		fmt.Println()
+	}
+
+	if len(knowledgeIssues) > 0 {
+		fmt.Printf("%sKnowledge bundles:%s\n\n", ansiText, ansiReset)
+		e, w := printAndCountDoctorIssues(knowledgeIssues)
 		totalErrors += e
 		totalWarnings += w
 		fmt.Println()

--- a/commands/experimental.go
+++ b/commands/experimental.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/experimental"
+	"github.com/sethcarney/mdm/internal/ui"
+)
+
+func buildExperimentalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "experimental",
+		Short: "Manage experimental features",
+		Long: fmt.Sprintf(`Manage experimental features.
+
+Experimental features may change or be removed in any release and are
+exempt from semantic versioning until they graduate.
+
+Features can also be enabled for a single invocation with the %s
+environment variable (comma-separated feature names, or "all"):
+
+  %s=knowledge mdm knowledge list`, experimental.EnvVar, experimental.EnvVar),
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		buildExperimentalListCmd(),
+		buildExperimentalEnableCmd(),
+		buildExperimentalDisableCmd(),
+	)
+	return cmd
+}
+
+func experimentalFeatureCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	names := make([]string, 0, len(experimental.All))
+	for _, info := range experimental.All {
+		names = append(names, string(info.Feature)+"\t"+info.Description)
+	}
+	sort.Strings(names)
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+func buildExperimentalListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "Show experimental features and their status",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println()
+			for _, info := range experimental.All {
+				status := ansiDim + "disabled" + ansiReset
+				switch {
+				case experimental.EnabledByEnv(info.Feature):
+					status = ansiGreen + "enabled" + ansiReset + ansiDim + " (via " + experimental.EnvVar + ")" + ansiReset
+				case experimental.Persisted(info.Feature):
+					status = ansiGreen + "enabled" + ansiReset
+				}
+				fmt.Printf("  %s%s%s  %s\n", ansiBold+ansiText, info.Feature, ansiReset, status)
+				fmt.Printf("      %s%s%s\n", ansiDim, info.Description, ansiReset)
+				fmt.Printf("      %sSpec: %s%s\n", ansiDim, info.SpecURL, ansiReset)
+			}
+			fmt.Println()
+			fmt.Printf("%sEnable with:%s mdm experimental enable <feature>\n\n", ansiDim, ansiReset)
+		},
+	}
+}
+
+func validateExperimentalFeature(name string) error {
+	if !experimental.IsKnown(name) {
+		return fmt.Errorf("unknown experimental feature %q; run 'mdm experimental list' to see available features", name)
+	}
+	return nil
+}
+
+func buildExperimentalEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:               "enable <feature>",
+		Short:             "Enable an experimental feature",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: experimentalFeatureCompletion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if err := validateExperimentalFeature(name); err != nil {
+				return err
+			}
+			if err := experimental.Enable(experimental.Feature(name)); err != nil {
+				return fmt.Errorf("could not persist experimental opt-in: %w", err)
+			}
+			ui.LogSuccess(fmt.Sprintf("%s enabled — this feature may change or be removed in any release", name))
+			return nil
+		},
+	}
+}
+
+func buildExperimentalDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:               "disable <feature>",
+		Short:             "Disable an experimental feature",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: experimentalFeatureCompletion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if err := validateExperimentalFeature(name); err != nil {
+				return err
+			}
+			if err := experimental.Disable(experimental.Feature(name)); err != nil {
+				return fmt.Errorf("could not persist experimental opt-out: %w", err)
+			}
+			ui.LogSuccess(fmt.Sprintf("%s disabled", name))
+			if experimental.EnabledByEnv(experimental.Feature(name)) {
+				ui.LogWarn(fmt.Sprintf("%s is still active via %s in this environment", name, experimental.EnvVar))
+			}
+			return nil
+		},
+	}
+}

--- a/commands/knowledge.go
+++ b/commands/knowledge.go
@@ -48,8 +48,10 @@ change or be removed in any release.
 		buildKnowledgeAddCmd(),
 		buildKnowledgeListCmd(),
 		buildKnowledgeRemoveCmd(),
+		buildKnowledgeUpdateCmd(),
 		buildKnowledgeValidateCmd(),
 		buildKnowledgeInitCmd(),
+		buildKnowledgeInstallCmd(),
 	)
 	return cmd
 }

--- a/commands/knowledge.go
+++ b/commands/knowledge.go
@@ -44,5 +44,9 @@ change or be removed in any release.
 			_ = cmd.Help()
 		},
 	}
+	cmd.AddCommand(
+		buildKnowledgeValidateCmd(),
+		buildKnowledgeInitCmd(),
+	)
 	return cmd
 }

--- a/commands/knowledge.go
+++ b/commands/knowledge.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/experimental"
+)
+
+// knowledgeSpecVersion is the OKF spec revision this build implements.
+// See docs/specs/knowledge.md and the upstream spec:
+// https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf
+const knowledgeSpecVersion = "0.1"
+
+func printKnowledgeBanner() {
+	fmt.Fprintf(os.Stderr, "%s⚠ experimental:%s %sOKF support tracks spec v%s — commands and file formats may change%s\n",
+		ansiYellow, ansiReset, ansiDim, knowledgeSpecVersion, ansiReset)
+}
+
+func buildKnowledgeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "knowledge",
+		Short:  "Manage OKF knowledge bundles [experimental]",
+		Hidden: !experimental.Enabled(experimental.Knowledge),
+		Long: fmt.Sprintf(`Manage Open Knowledge Format (OKF) bundles — directories of markdown
+documents that give AI agents durable reference context.
+
+This command group is experimental: it tracks OKF spec v%s and may
+change or be removed in any release.
+
+%sExamples:%s
+  mdm knowledge validate ./knowledge/my-bundle
+  mdm knowledge init my-bundle`, knowledgeSpecVersion, ansiBold, ansiReset),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if !experimental.Enabled(experimental.Knowledge) {
+				return fmt.Errorf("knowledge is experimental — enable it with 'mdm experimental enable knowledge' or %s=knowledge", experimental.EnvVar)
+			}
+			printKnowledgeBanner()
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+	}
+	return cmd
+}

--- a/commands/knowledge.go
+++ b/commands/knowledge.go
@@ -45,6 +45,9 @@ change or be removed in any release.
 		},
 	}
 	cmd.AddCommand(
+		buildKnowledgeAddCmd(),
+		buildKnowledgeListCmd(),
+		buildKnowledgeRemoveCmd(),
 		buildKnowledgeValidateCmd(),
 		buildKnowledgeInitCmd(),
 	)

--- a/commands/knowledge_add.go
+++ b/commands/knowledge_add.go
@@ -1,0 +1,300 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/git"
+	"github.com/sethcarney/mdm/internal/lock"
+	"github.com/sethcarney/mdm/internal/okf"
+	"github.com/sethcarney/mdm/internal/security/markdownscan"
+	"github.com/sethcarney/mdm/internal/source"
+	"github.com/sethcarney/mdm/internal/ui"
+)
+
+// defaultKnowledgeDir is where bundles land, relative to the project root.
+const defaultKnowledgeDir = "knowledge"
+
+type KnowledgeAddOptions struct {
+	Dir              string
+	Bundles          []string
+	Yes              bool
+	DryRun           bool
+	AllowHiddenChars bool
+}
+
+func buildKnowledgeAddCmd() *cobra.Command {
+	var opts KnowledgeAddOptions
+
+	cmd := &cobra.Command{
+		Use:     "add <source>",
+		Short:   "Install an OKF bundle from GitHub, GitLab, URL, or local path",
+		Aliases: []string{"a"},
+		Long: fmt.Sprintf(`Install a knowledge bundle into the project's knowledge directory
+(default ./%s) and record it in knowledge-lock.json.
+
+Sources use the same forms as skills: owner/repo shorthand, full URLs,
+and local paths, with an optional #ref for version pinning.
+
+%sExamples:%s
+  mdm knowledge add acme/sales-knowledge
+  mdm knowledge add acme/sales-knowledge#v2.1.0
+  mdm knowledge add https://github.com/acme/sales-knowledge
+  mdm knowledge add ./local-bundle`, defaultKnowledgeDir, ansiBold, ansiReset),
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runKnowledgeAdd(args[0], opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&opts.Dir, "dir", defaultKnowledgeDir, "Directory to install bundles into (relative to the project root)")
+	f.StringArrayVarP(&opts.Bundles, "bundle", "b", nil, "Bundle names to install (repeatable, use '*' for all)")
+	f.BoolVarP(&opts.Yes, "yes", "y", false, "Skip confirmation prompts and install all discovered bundles")
+	f.BoolVar(&opts.DryRun, "dry-run", false, "Show what would be installed without writing anything")
+	f.BoolVar(&opts.AllowHiddenChars, "allow-hidden-chars", false, "Allow markdown files with hidden Unicode characters")
+
+	return cmd
+}
+
+// knowledgeCandidate is a discovered bundle root awaiting install.
+type knowledgeCandidate struct {
+	Name string
+	Root string
+	Docs int
+}
+
+func runKnowledgeAdd(sourceInput string, opts KnowledgeAddOptions) {
+	cwd, _ := os.Getwd()
+	parsed := source.ParseSource(sourceInput)
+	vlog(verboseFlag, "source %q → type=%s url=%s ref=%q subpath=%q",
+		sourceInput, parsed.Type, parsed.URL, parsed.Ref, parsed.Subpath)
+	fmt.Println()
+
+	searchRoot, cleanup := fetchKnowledgeSource(parsed)
+	defer cleanup()
+
+	candidates := discoverKnowledgeCandidates(searchRoot, parsed)
+	if len(candidates) == 0 {
+		fmt.Fprintf(os.Stderr, "%sNo knowledge bundles found in %s%s\n", ansiText, sourceInput, ansiReset)
+		os.Exit(1)
+	}
+
+	selected, ok := selectKnowledgeCandidates(candidates, opts)
+	if !ok {
+		return
+	}
+
+	if !scanKnowledgeCandidates(selected, opts.AllowHiddenChars) {
+		os.Exit(1)
+	}
+
+	baseEntry := knowledgeLockEntry(parsed, sourceInput)
+	installed := 0
+	for _, c := range selected {
+		if installKnowledgeCandidate(c, baseEntry, opts, cwd) {
+			installed++
+		}
+	}
+	fmt.Println()
+	if opts.DryRun {
+		fmt.Printf("%sDry run — nothing was written.%s\n\n", ansiDim, ansiReset)
+		return
+	}
+	fmt.Printf("%sInstalled %d bundle(s) to ./%s%s\n\n", ansiText, installed, opts.Dir, ansiReset)
+}
+
+// fetchKnowledgeSource materializes the source on disk and returns the
+// directory to search plus a cleanup func for any temp clone.
+func fetchKnowledgeSource(parsed source.ParsedSource) (string, func()) {
+	noop := func() {}
+	switch parsed.Type {
+	case source.SourceTypeLocal:
+		if _, err := os.Stat(parsed.LocalPath); err != nil {
+			fmt.Fprintf(os.Stderr, "%sError:%s Path not found: %s\n", ansiText, ansiReset, parsed.LocalPath)
+			os.Exit(1)
+		}
+		return parsed.LocalPath, noop
+	case source.SourceTypeWellKnown:
+		fmt.Fprintf(os.Stderr, "%sError:%s well-known registries are not supported for knowledge bundles\n", ansiText, ansiReset)
+		os.Exit(1)
+		return "", noop
+	default:
+		spin := ui.NewSpinner("Cloning " + parsed.URL + "...")
+		tmpDir, err := git.CloneRepo(parsed.URL, parsed.Ref)
+		spin.Stop("")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%sError:%s %s\n", ansiText, ansiReset, err.Error())
+			os.Exit(1)
+		}
+		searchRoot := tmpDir
+		if parsed.Subpath != "" {
+			searchRoot = filepath.Join(tmpDir, parsed.Subpath)
+			if _, err := os.Stat(searchRoot); err != nil {
+				git.CleanupTempDir(tmpDir)
+				fmt.Fprintf(os.Stderr, "%sSubpath not found:%s %s\n", ansiText, ansiReset, parsed.Subpath)
+				os.Exit(1)
+			}
+		}
+		return searchRoot, func() { git.CleanupTempDir(tmpDir) }
+	}
+}
+
+// discoverKnowledgeCandidates finds bundle roots and names them: nested
+// bundles after their directory, a root-level bundle after the repo or
+// source directory.
+func discoverKnowledgeCandidates(searchRoot string, parsed source.ParsedSource) []knowledgeCandidate {
+	var candidates []knowledgeCandidate
+	for _, root := range okf.FindBundleRoots(searchRoot) {
+		name := filepath.Base(root)
+		if root == searchRoot {
+			if ownerRepo := source.GetOwnerRepo(parsed); ownerRepo != "" {
+				name = filepath.Base(ownerRepo)
+			}
+		}
+		docs := 0
+		if b, err := okf.LoadBundle(root); err == nil {
+			docs = len(b.Docs)
+		}
+		candidates = append(candidates, knowledgeCandidate{Name: sanitizeName(name), Root: root, Docs: docs})
+	}
+	return candidates
+}
+
+func filterKnowledgeCandidates(candidates []knowledgeCandidate, filters []string) []knowledgeCandidate {
+	if len(filters) == 1 && filters[0] == "*" {
+		return candidates
+	}
+	var keep []knowledgeCandidate
+	for _, c := range candidates {
+		for _, f := range filters {
+			if skillNameMatches(c.Name, f) {
+				keep = append(keep, c)
+				break
+			}
+		}
+	}
+	return keep
+}
+
+func selectKnowledgeCandidates(candidates []knowledgeCandidate, opts KnowledgeAddOptions) ([]knowledgeCandidate, bool) {
+	if len(opts.Bundles) > 0 {
+		keep := filterKnowledgeCandidates(candidates, opts.Bundles)
+		if len(keep) == 0 {
+			fmt.Fprintf(os.Stderr, "%sNo matching bundles found.%s\n", ansiText, ansiReset)
+			os.Exit(1)
+		}
+		return keep, true
+	}
+	if opts.Yes || len(candidates) == 1 {
+		return candidates, true
+	}
+	options := make([]ui.UIOption, len(candidates))
+	for i, c := range candidates {
+		options[i] = ui.UIOption{Label: c.Name, Value: c.Name, Hint: fmt.Sprintf("%d document(s)", c.Docs)}
+	}
+	indices, ok := ui.UiMultiselect("Which bundles would you like to install?", options, true, nil, nil)
+	if !ok {
+		fmt.Println("Cancelled.")
+		return nil, false
+	}
+	var selected []knowledgeCandidate
+	for _, i := range indices {
+		selected = append(selected, candidates[i])
+	}
+	return selected, true
+}
+
+// scanKnowledgeCandidates runs the hidden-character scan over every selected
+// bundle. Bundles are agent-bound markdown, so this gate is mandatory.
+func scanKnowledgeCandidates(selected []knowledgeCandidate, allow bool) bool {
+	ok := true
+	for _, c := range selected {
+		findings, err := markdownscan.ScanMarkdownFiles(c.Root)
+		if err != nil {
+			fmt.Printf("%sHidden character scan failed for %s: %s%s\n", ansiRed, c.Name, err, ansiReset)
+			ok = false
+			continue
+		}
+		if !checkSkillMarkdownForHiddenChars(c.Name, findings, allow) {
+			ok = false
+		}
+	}
+	return ok
+}
+
+// knowledgeLockEntry builds the source-level part of the lock entry shared by
+// every bundle installed from this invocation.
+func knowledgeLockEntry(parsed source.ParsedSource, sourceInput string) lock.KnowledgeLockEntry {
+	entry := lock.KnowledgeLockEntry{
+		Source:      stripSourceRef(sourceInput),
+		SourceType:  string(parsed.Type),
+		SourceURL:   parsed.URL,
+		Subpath:     parsed.Subpath,
+		SpecVersion: knowledgeSpecVersion,
+	}
+	if parsed.Type == source.SourceTypeLocal {
+		entry.Source = parsed.LocalPath
+		entry.SourceURL = ""
+	} else {
+		entry.Ref = parsed.Ref
+		if entry.Ref == "" {
+			entry.Ref = git.DefaultBranch(parsed.URL)
+		}
+	}
+	return entry
+}
+
+func installKnowledgeCandidate(c knowledgeCandidate, baseEntry lock.KnowledgeLockEntry, opts KnowledgeAddOptions, cwd string) bool {
+	issues := validateKnowledgeCandidate(c)
+
+	if opts.DryRun {
+		fmt.Printf("  %s%s%s  %d document(s) → ./%s\n", ansiText, c.Name, ansiReset, c.Docs, filepath.ToSlash(filepath.Join(opts.Dir, c.Name)))
+		return true
+	}
+
+	destBase := filepath.Join(cwd, opts.Dir)
+	destDir := filepath.Join(destBase, c.Name)
+	if !isPathSafe(destBase, destDir) || !isPathSafe(cwd, destBase) {
+		ui.LogError(fmt.Sprintf("%s: potential path traversal detected", c.Name))
+		return false
+	}
+	if err := cleanAndCreateDir(destDir); err != nil {
+		ui.LogError(fmt.Sprintf("%s: %v", c.Name, err))
+		return false
+	}
+	if err := copyDirectory(c.Root, destDir); err != nil {
+		ui.LogError(fmt.Sprintf("%s: %v", c.Name, err))
+		return false
+	}
+
+	entry := baseEntry
+	entry.InstallDir = filepath.ToSlash(filepath.Join(opts.Dir, c.Name))
+	if hash, err := okf.HashBundleDir(destDir); err == nil {
+		entry.ContentHash = hash
+	}
+	if err := lock.AddBundleToKnowledgeLock(c.Name, entry, cwd); err != nil {
+		ui.LogWarn(fmt.Sprintf("could not update knowledge-lock.json: %v", err))
+	}
+
+	msg := fmt.Sprintf("%s (%d document(s))", c.Name, c.Docs)
+	if n := len(issues); n > 0 {
+		msg += fmt.Sprintf(" — %d validation issue(s), run 'mdm knowledge validate %s'", n, entry.InstallDir)
+	}
+	ui.LogSuccess(msg)
+	return true
+}
+
+// validateKnowledgeCandidate reports conformance issues without blocking the
+// install; an imperfect bundle is still useful and `validate` exists for
+// strict checking.
+func validateKnowledgeCandidate(c knowledgeCandidate) []okf.Issue {
+	b, err := okf.LoadBundle(c.Root)
+	if err != nil {
+		return nil
+	}
+	return okf.Validate(b)
+}

--- a/commands/knowledge_doctor.go
+++ b/commands/knowledge_doctor.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/sethcarney/mdm/internal/lock"
+	"github.com/sethcarney/mdm/internal/okf"
+)
+
+// checkKnowledgeBundles diagnoses installed knowledge bundles against
+// knowledge-lock.json: missing directories, content drift since install, and
+// OKF conformance errors. Only called when the knowledge experimental gate is
+// enabled, so doctor output is unchanged for everyone else.
+func checkKnowledgeBundles(cwd string) []doctorIssue {
+	lk := lock.ReadKnowledgeLock(cwd)
+	if len(lk.Bundles) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(lk.Bundles))
+	for name := range lk.Bundles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var issues []doctorIssue
+	for _, name := range names {
+		issues = append(issues, diagnoseKnowledgeBundle(name, lk.Bundles[name], cwd)...)
+	}
+	return issues
+}
+
+func diagnoseKnowledgeBundle(name string, entry lock.KnowledgeLockEntry, cwd string) []doctorIssue {
+	dir := filepath.Join(cwd, filepath.FromSlash(entry.InstallDir))
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return []doctorIssue{{
+			Level:   "error",
+			Message: fmt.Sprintf("%s: bundle directory ./%s not found — run `mdm knowledge install` to restore", name, entry.InstallDir),
+		}}
+	}
+
+	var issues []doctorIssue
+	if entry.ContentHash != "" {
+		if hash, err := okf.HashBundleDir(dir); err == nil && hash != entry.ContentHash {
+			issues = append(issues, doctorIssue{
+				Level:   "warn",
+				Message: fmt.Sprintf("%s: modified since install (content hash mismatch) — run `mdm knowledge update %s` to re-fetch", name, name),
+			})
+		}
+	}
+	if b, err := okf.LoadBundle(dir); err == nil {
+		if conformance := okf.Validate(b); okf.HasErrors(conformance) {
+			errs := 0
+			for _, issue := range conformance {
+				if issue.Severity == okf.SeverityError {
+					errs++
+				}
+			}
+			issues = append(issues, doctorIssue{
+				Level:   "warn",
+				Message: fmt.Sprintf("%s: %d conformance error(s) — run `mdm knowledge validate ./%s`", name, errs, entry.InstallDir),
+			})
+		}
+	}
+	return issues
+}

--- a/commands/knowledge_init.go
+++ b/commands/knowledge_init.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func buildKnowledgeInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init [name]",
+		Short: "Scaffold a new OKF bundle",
+		Long: fmt.Sprintf(`Initialize a minimal, conformant OKF bundle in the current directory.
+
+Creates <name>/index.md and an example concept document, or scaffolds
+into the current directory if no name is given.
+
+%sExamples:%s
+  mdm knowledge init
+  mdm knowledge init sales`, ansiBold, ansiReset),
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runKnowledgeInit(args)
+		},
+	}
+}
+
+func knowledgeIndexTemplate(name string) string {
+	return fmt.Sprintf(`---
+title: %s
+description: Knowledge bundle for %s.
+---
+
+# %s
+
+Curated context for AI agents. Each concept lives in its own document;
+link related concepts with ordinary markdown links.
+
+## Concepts
+
+- [Example concept](concepts/example-concept.md)
+`, name, name, name)
+}
+
+const knowledgeConceptTemplate = `---
+type: Concept
+title: Example concept
+description: Replace with one fact, definition, or playbook worth remembering.
+tags: [example]
+---
+
+# Example concept
+
+Describe one thing an agent should know about this domain: what it is,
+where it lives, and how it relates to other concepts.
+
+Link related documents with markdown links — root-relative from the
+bundle, like [the index](/index.md), or relative to this file.
+`
+
+func runKnowledgeInit(args []string) {
+	cwd, _ := os.Getwd()
+	bundleDir := cwd
+	name := filepath.Base(cwd)
+	if len(args) > 0 && args[0] != "" {
+		name = args[0]
+		bundleDir = filepath.Join(cwd, name)
+	}
+
+	indexPath := filepath.Join(bundleDir, "index.md")
+	if _, err := os.Stat(indexPath); err == nil {
+		fmt.Printf("%sBundle already exists at %s%s%s\n", ansiText, ansiDim, indexPath, ansiReset)
+		return
+	}
+
+	conceptDir := filepath.Join(bundleDir, "concepts")
+	if err := os.MkdirAll(conceptDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating directory: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(indexPath, []byte(knowledgeIndexTemplate(name)), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
+		os.Exit(1)
+	}
+	conceptPath := filepath.Join(conceptDir, "example-concept.md")
+	if err := os.WriteFile(conceptPath, []byte(knowledgeConceptTemplate), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
+		os.Exit(1)
+	}
+
+	rel := func(p string) string {
+		if r, err := filepath.Rel(cwd, p); err == nil {
+			return r
+		}
+		return p
+	}
+	fmt.Printf("%sInitialized knowledge bundle: %s%s%s\n", ansiText, ansiDim, name, ansiReset)
+	fmt.Println()
+	fmt.Printf("%sCreated:%s\n", ansiDim, ansiReset)
+	fmt.Printf("  %s\n", rel(indexPath))
+	fmt.Printf("  %s\n", rel(conceptPath))
+	fmt.Println()
+	fmt.Printf("%sNext steps:%s\n", ansiDim, ansiReset)
+	fmt.Printf("  1. Replace the example concept with real documents (one concept per file)\n")
+	fmt.Printf("  2. Keep %sindex.md%s linking to every top-level concept\n", ansiText, ansiReset)
+	fmt.Printf("  3. Check conformance with %smdm knowledge validate %s%s\n", ansiText, rel(bundleDir), ansiReset)
+	fmt.Println()
+}

--- a/commands/knowledge_install.go
+++ b/commands/knowledge_install.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/lock"
+)
+
+func buildKnowledgeInstallCmd() *cobra.Command {
+	var allowHiddenChars bool
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Restore all bundles from knowledge-lock.json",
+		Long: `Restore every knowledge bundle recorded in knowledge-lock.json,
+re-fetching each from its recorded source and ref. Intended for CI and
+onboarding, like 'mdm skills install'.`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runKnowledgeInstall(allowHiddenChars)
+		},
+	}
+
+	cmd.Flags().BoolVar(&allowHiddenChars, "allow-hidden-chars", false, "Allow markdown files with hidden Unicode characters")
+	return cmd
+}
+
+func runKnowledgeInstall(allowHiddenChars bool) {
+	cwd, _ := os.Getwd()
+	lk := lock.ReadKnowledgeLock(cwd)
+	if len(lk.Bundles) == 0 {
+		fmt.Printf("\n%sNo knowledge-lock.json found.%s\n\n", ansiDim, ansiReset)
+		fmt.Printf("Add bundles with %smdm knowledge add <source>%s\n\n", ansiText, ansiReset)
+		return
+	}
+
+	names := selectKnowledgeLockEntries(lk, nil)
+	fmt.Printf("\n%sRestoring %d bundle(s) from knowledge-lock.json...%s\n", ansiText, len(names), ansiReset)
+	for _, name := range names {
+		reinstallKnowledgeBundle(name, lk.Bundles[name], allowHiddenChars)
+	}
+	fmt.Printf("%sDone.%s\n\n", ansiText, ansiReset)
+}

--- a/commands/knowledge_list.go
+++ b/commands/knowledge_list.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/lock"
+	"github.com/sethcarney/mdm/internal/okf"
+	"github.com/sethcarney/mdm/internal/source"
+)
+
+func buildKnowledgeListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List installed knowledge bundles",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runKnowledgeList()
+		},
+	}
+}
+
+func runKnowledgeList() {
+	cwd, _ := os.Getwd()
+	lk := lock.ReadKnowledgeLock(cwd)
+	if len(lk.Bundles) == 0 {
+		fmt.Printf("\n%sNo knowledge bundles installed.%s\n\n", ansiDim, ansiReset)
+		fmt.Printf("Add one with %smdm knowledge add <source>%s\n\n", ansiText, ansiReset)
+		return
+	}
+
+	names := make([]string, 0, len(lk.Bundles))
+	for name := range lk.Bundles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fmt.Println()
+	for _, name := range names {
+		entry := lk.Bundles[name]
+		installDir := filepath.Join(cwd, filepath.FromSlash(entry.InstallDir))
+		status := ""
+		docs := 0
+		if b, err := okf.LoadBundle(installDir); err == nil {
+			docs = len(b.Docs)
+		} else {
+			status = ansiRed + "  missing on disk" + ansiReset
+		}
+		fmt.Printf("  %s%s%s  %s%d document(s)%s%s\n", ansiBold+ansiText, name, ansiReset, ansiDim, docs, ansiReset, status)
+		fmt.Printf("      %s%s  spec v%s%s\n", ansiDim, source.FormatSourceInput(entry.Source, entry.Ref), entry.SpecVersion, ansiReset)
+		fmt.Printf("      %s./%s%s\n", ansiDim, entry.InstallDir, ansiReset)
+	}
+	fmt.Println()
+}

--- a/commands/knowledge_remove.go
+++ b/commands/knowledge_remove.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/lock"
+	"github.com/sethcarney/mdm/internal/ui"
+)
+
+func buildKnowledgeRemoveCmd() *cobra.Command {
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:     "remove [bundles...]",
+		Short:   "Remove installed knowledge bundles",
+		Aliases: []string{"rm", "r"},
+		Long: fmt.Sprintf(`Remove knowledge bundles and their knowledge-lock.json entries.
+
+If no bundle names are provided an interactive selection menu is shown.
+
+%sExamples:%s
+  mdm knowledge remove
+  mdm knowledge remove sales -y`, ansiBold, ansiReset),
+		Args: cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runKnowledgeRemove(args, yes)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	return cmd
+}
+
+func selectKnowledgeToRemove(lk lock.KnowledgeLockFile, names []string, yes bool) ([]string, bool) {
+	if len(names) > 0 {
+		var keep []string
+		for _, name := range names {
+			if _, ok := lk.Bundles[sanitizeName(name)]; ok {
+				keep = append(keep, sanitizeName(name))
+			} else {
+				ui.LogWarn(fmt.Sprintf("%s is not in knowledge-lock.json", name))
+			}
+		}
+		return keep, len(keep) > 0
+	}
+
+	all := make([]string, 0, len(lk.Bundles))
+	for name := range lk.Bundles {
+		all = append(all, name)
+	}
+	sort.Strings(all)
+	if yes || len(all) == 1 {
+		return all, true
+	}
+	options := make([]ui.UIOption, len(all))
+	for i, name := range all {
+		options[i] = ui.UIOption{Label: name, Value: name, Hint: "./" + lk.Bundles[name].InstallDir}
+	}
+	indices, ok := ui.UiMultiselect("Which bundles would you like to remove?", options, true, nil, nil)
+	if !ok {
+		fmt.Println("Cancelled.")
+		return nil, false
+	}
+	var selected []string
+	for _, i := range indices {
+		selected = append(selected, all[i])
+	}
+	return selected, true
+}
+
+func runKnowledgeRemove(names []string, yes bool) {
+	cwd, _ := os.Getwd()
+	lk := lock.ReadKnowledgeLock(cwd)
+	if len(lk.Bundles) == 0 {
+		fmt.Printf("\n%sNo knowledge bundles installed.%s\n\n", ansiDim, ansiReset)
+		return
+	}
+
+	selected, ok := selectKnowledgeToRemove(lk, names, yes)
+	if !ok {
+		return
+	}
+
+	fmt.Println()
+	for _, name := range selected {
+		entry := lk.Bundles[name]
+		installDir := filepath.Join(cwd, filepath.FromSlash(entry.InstallDir))
+		if !isPathSafe(cwd, installDir) || installDir == filepath.Clean(cwd) {
+			ui.LogError(fmt.Sprintf("%s: refusing to remove %s", name, entry.InstallDir))
+			continue
+		}
+		if err := os.RemoveAll(installDir); err != nil {
+			ui.LogError(fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+		if err := lock.RemoveBundleFromKnowledgeLock(name, cwd); err != nil {
+			ui.LogWarn(fmt.Sprintf("could not update knowledge-lock.json: %v", err))
+		}
+		ui.LogSuccess(name)
+	}
+	fmt.Println()
+}

--- a/commands/knowledge_update.go
+++ b/commands/knowledge_update.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/lock"
+	"github.com/sethcarney/mdm/internal/source"
+)
+
+func buildKnowledgeUpdateCmd() *cobra.Command {
+	var allowHiddenChars bool
+
+	cmd := &cobra.Command{
+		Use:   "update [bundles...]",
+		Short: "Re-fetch installed bundles from their recorded source and ref",
+		Long: fmt.Sprintf(`Re-fetch knowledge bundles from the source and ref recorded in
+knowledge-lock.json, re-running the hidden-character scan and
+conformance validation.
+
+%sExamples:%s
+  mdm knowledge update
+  mdm knowledge update sales`, ansiBold, ansiReset),
+		Args: cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runKnowledgeUpdate(args, allowHiddenChars)
+		},
+	}
+
+	cmd.Flags().BoolVar(&allowHiddenChars, "allow-hidden-chars", false, "Allow markdown files with hidden Unicode characters")
+	return cmd
+}
+
+// selectKnowledgeLockEntries returns the sorted lock entry names matching the
+// given filters (all entries when no filter is given).
+func selectKnowledgeLockEntries(lk lock.KnowledgeLockFile, filters []string) []string {
+	var names []string
+	for name := range lk.Bundles {
+		if len(filters) == 0 {
+			names = append(names, name)
+			continue
+		}
+		for _, f := range filters {
+			if skillNameMatches(name, f) {
+				names = append(names, name)
+				break
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// reinstallKnowledgeBundle re-fetches one lock entry and reinstalls it into
+// its recorded directory, refreshing the lock entry's hash and UpdatedAt.
+func reinstallKnowledgeBundle(name string, entry lock.KnowledgeLockEntry, allowHiddenChars bool) {
+	src := entry.Source
+	if entry.Ref != "" && entry.SourceType != string(source.SourceTypeLocal) && !strings.Contains(src, "#") {
+		src += "#" + entry.Ref
+	}
+	runKnowledgeAdd(src, KnowledgeAddOptions{
+		Dir:              filepath.FromSlash(path.Dir(entry.InstallDir)),
+		Bundles:          []string{name},
+		Yes:              true,
+		AllowHiddenChars: allowHiddenChars,
+	})
+}
+
+func runKnowledgeUpdate(filters []string, allowHiddenChars bool) {
+	cwd, _ := os.Getwd()
+	lk := lock.ReadKnowledgeLock(cwd)
+	if len(lk.Bundles) == 0 {
+		fmt.Printf("\n%sNo knowledge bundles installed.%s\n\n", ansiDim, ansiReset)
+		return
+	}
+
+	names := selectKnowledgeLockEntries(lk, filters)
+	if len(names) == 0 {
+		fmt.Printf("\n%sNo matching bundles found in knowledge-lock.json.%s\n\n", ansiDim, ansiReset)
+		return
+	}
+
+	for _, name := range names {
+		entry := lk.Bundles[name]
+		fmt.Printf("%sUpdating %s from %s...%s\n", ansiDim, name, source.FormatSourceInput(entry.Source, entry.Ref), ansiReset)
+		reinstallKnowledgeBundle(name, entry, allowHiddenChars)
+	}
+	fmt.Printf("%sUpdate complete:%s %d bundle(s) refreshed\n\n", ansiText, ansiReset, len(names))
+}

--- a/commands/knowledge_validate.go
+++ b/commands/knowledge_validate.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sethcarney/mdm/internal/okf"
+)
+
+func buildKnowledgeValidateCmd() *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "validate [path]",
+		Short: "Validate an OKF bundle",
+		Long: fmt.Sprintf(`Validate a knowledge bundle against OKF v%s conformance rules.
+
+Checks the required frontmatter (every concept document needs a "type"
+field), cross-link integrity (every markdown link must resolve to a
+document inside the bundle), and warns about orphaned documents and
+malformed timestamps.
+
+Exits non-zero when errors are found; warnings alone do not fail
+validation.
+
+%sExamples:%s
+  mdm knowledge validate                # validate the current directory
+  mdm knowledge validate ./knowledge/sales
+  mdm knowledge validate ./knowledge/sales --json`, knowledgeSpecVersion, ansiBold, ansiReset),
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			path := "."
+			if len(args) > 0 {
+				path = args[0]
+			}
+			runKnowledgeValidate(path, jsonOut)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Print the validation report as JSON")
+	return cmd
+}
+
+type knowledgeValidateReport struct {
+	Bundle      string      `json:"bundle"`
+	SpecVersion string      `json:"specVersion"`
+	Documents   int         `json:"documents"`
+	Errors      int         `json:"errors"`
+	Warnings    int         `json:"warnings"`
+	Issues      []okf.Issue `json:"issues"`
+}
+
+func countKnowledgeIssues(issues []okf.Issue) (errs, warns int) {
+	for _, issue := range issues {
+		if issue.Severity == okf.SeverityError {
+			errs++
+		} else {
+			warns++
+		}
+	}
+	return errs, warns
+}
+
+func runKnowledgeValidate(path string, jsonOut bool) {
+	bundle, err := okf.LoadBundle(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%sError:%s %s\n", ansiText, ansiReset, err)
+		os.Exit(1)
+	}
+	issues := okf.Validate(bundle)
+	errs, warns := countKnowledgeIssues(issues)
+
+	if jsonOut {
+		report := knowledgeValidateReport{
+			Bundle:      path,
+			SpecVersion: knowledgeSpecVersion,
+			Documents:   len(bundle.Docs),
+			Errors:      errs,
+			Warnings:    warns,
+			Issues:      issues,
+		}
+		if report.Issues == nil {
+			report.Issues = []okf.Issue{}
+		}
+		data, _ := json.MarshalIndent(report, "", "  ")
+		fmt.Println(string(data))
+	} else {
+		printKnowledgeValidateReport(bundle, issues, errs, warns)
+	}
+
+	if okf.HasErrors(issues) {
+		os.Exit(1)
+	}
+}
+
+func printKnowledgeValidateReport(bundle *okf.Bundle, issues []okf.Issue, errs, warns int) {
+	fmt.Println()
+	for _, issue := range issues {
+		sevColor := ansiYellow
+		if issue.Severity == okf.SeverityError {
+			sevColor = ansiRed
+		}
+		loc := issue.File
+		if issue.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", issue.File, issue.Line)
+		}
+		if loc == "" {
+			loc = bundle.Root
+		}
+		fmt.Printf("  %s%-7s%s %s%s%s  %s%s%s  %s\n",
+			sevColor, issue.Severity, ansiReset,
+			ansiText, loc, ansiReset,
+			ansiDim, issue.Rule, ansiReset,
+			issue.Message)
+	}
+	if len(issues) > 0 {
+		fmt.Println()
+	}
+	switch {
+	case errs > 0:
+		fmt.Printf("%s✗%s %d document(s) — %d error(s), %d warning(s)\n\n", ansiRed, ansiReset, len(bundle.Docs), errs, warns)
+	case warns > 0:
+		fmt.Printf("%s✓%s %d document(s) valid — %d warning(s)\n\n", ansiGreen, ansiReset, len(bundle.Docs), warns)
+	default:
+		fmt.Printf("%s✓%s %d document(s) valid — no issues\n\n", ansiGreen, ansiReset, len(bundle.Docs))
+	}
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -117,9 +117,11 @@ func BuildRootCmd(ver string) *cobra.Command {
 
 	root.AddCommand(
 		buildSkillsCmd(ver),
+		buildKnowledgeCmd(),
 		buildAgentsCmd(),
 		buildRulesCmd(),
 		buildDoctorCmd(),
+		buildExperimentalCmd(),
 		buildUpgradeCmd(ver),
 		buildUninstallCmd(),
 		buildCompletionCmd(root),

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,0 +1,44 @@
+# Experimental features
+
+Some mdm features ship behind an experimental gate while the standards or
+conventions they build on are still settling. Experimental features:
+
+- may change or be removed in **any** release — they are exempt from semantic
+  versioning until they graduate
+- are hidden from `--help` and shell completion until enabled
+- print a warning banner on every invocation while enabled
+- never touch state used by stable features (e.g. they use their own lock
+  files), so enabling one cannot corrupt a stable workflow
+
+## Enabling a feature
+
+Persistently, per user:
+
+```bash
+mdm experimental enable knowledge
+```
+
+Or for a single invocation / CI, via the environment (comma-separated feature
+names, or `all`):
+
+```bash
+MDM_EXPERIMENTAL=knowledge mdm knowledge list
+```
+
+The environment variable always wins: it activates a feature even if it was
+disabled with `mdm experimental disable`.
+
+## Commands
+
+```
+mdm experimental
+├── list                 # show features, status, and spec links
+├── enable <feature>     # persist an opt-in (stored in the global lock file)
+└── disable <feature>    # remove the persisted opt-in
+```
+
+## Current experimental features
+
+| Feature | What it does | Spec |
+|---|---|---|
+| `knowledge` | Manage Open Knowledge Format (OKF) bundles — install, validate, and audit markdown knowledge bases for AI agents. See [docs/specs/knowledge.md](specs/knowledge.md). | [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) |

--- a/docs/specs/knowledge.md
+++ b/docs/specs/knowledge.md
@@ -1,0 +1,362 @@
+# Spec: Experimental OKF Knowledge Support (`mdm knowledge`)
+
+| | |
+|---|---|
+| **Status** | Draft |
+| **Stability** | Experimental — gated behind `MDM_EXPERIMENTAL=knowledge` / `mdm experimental enable knowledge` |
+| **Author** | Dakota Kim |
+| **Created** | 2026-07-06 |
+| **Tracking issue** | TBD |
+| **External spec** | [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) |
+
+## Summary
+
+Add an experimental `mdm knowledge` command group that installs, validates, and
+manages **Open Knowledge Format (OKF) bundles** — directories of markdown files
+with YAML frontmatter that give AI agents durable reference context ("LLM-wiki"
+pattern). The feature reuses mdm's existing acquisition, locking, and security
+pipeline, ships behind a named experimental gate, and makes no stability
+promises while OKF itself is at v0.1.
+
+Skills tell an agent **how to do a task**. Knowledge bundles tell an agent
+**what is true about a system**. mdm already solves fetch/verify/place/pin/audit
+for the first; this spec extends the same pipeline to the second.
+
+## Background
+
+Google published OKF v0.1 in June 2026. A bundle is a directory of markdown
+files where each file is one concept, the file path is the concept's identity,
+concepts cross-link with ordinary markdown links, and optional `index.md` files
+provide hierarchical navigation. Frontmatter requires only `type`; `title`,
+`description`, `resource`, `tags`, and `timestamp` are reserved but optional.
+Distribution is deliberately plain: "shipped as a tarball, hosted in any repo,
+mounted from any filesystem."
+
+This maps almost one-to-one onto what mdm already does for skills:
+
+| Pipeline stage | Existing package | Reuse for OKF |
+|---|---|---|
+| Parse source (GitHub/GitLab/URL/local) | `internal/source` | As-is |
+| Shallow clone / API fetch | `internal/git`, `internal/blob` | As-is |
+| Discover markdown artifacts | `internal/skill` | New sibling: `internal/okf` |
+| Hidden-character / prompt-smuggling scan | `internal/security` | As-is (higher value here — see below) |
+| Pin source+ref+hash in a lock file | `internal/lock` | New file: `knowledge-lock.json` |
+| Health checks | `commands/doctor.go` | Extend when gate is enabled |
+
+The genuinely new code is OKF bundle discovery/validation and the experimental
+gate itself.
+
+## Goals
+
+1. **Install and manage OKF bundles** from the same source types skills support
+   (GitHub, GitLab, direct URL, local path), pinned in a lock file, restorable
+   in CI.
+2. **Validate bundles** against OKF v0.1: required `type` frontmatter, reserved
+   filename rules, cross-link integrity, orphaned-document detection.
+3. **Scan bundles for prompt-injection vectors** (hidden characters, smuggled
+   instructions) before they land in an agent's context. OKF documents are
+   *designed* to be fed to agents and to be written by agents, which makes them
+   a first-class injection surface; no other OKF tooling does this today.
+4. **Evolve alongside the standard without stability debt**: everything ships
+   behind a named experimental gate, records the OKF spec version it targets,
+   and is exempt from semver until graduation.
+5. **Zero impact when disabled**: users who never enable the gate see no new
+   commands, no new files, no behavior change, and cannot have state corrupted
+   by the experiment.
+
+## Non-goals (for the experimental phase)
+
+- **Authoring/enrichment pipelines** — generating OKF content from BigQuery,
+  databases, or codebases is Google's reference-agent territory, not mdm's.
+- **A knowledge registry or search** — there is no skills.sh equivalent for
+  OKF yet; `mdm knowledge find` is out of scope until an ecosystem exists.
+- **Rendering/visualization** — the OKF repo ships an HTML visualizer; we
+  don't compete with it.
+- **Automatic agent wiring** — injecting bundle references into
+  CLAUDE.md/AGENTS.md is deferred to a later phase (see Future value); it
+  needs its own design because it mutates user-owned files.
+- **Serving knowledge at runtime** (MCP server, HTTP) — out of scope entirely.
+
+## Value today — an honest assessment
+
+Be clear-eyed about this: **the immediate practical value is modest.**
+
+- OKF is **three weeks old at v0.1**. The known corpus of conformant bundles is
+  Google's three samples (GA4, Stack Overflow, Bitcoin). There is no registry,
+  no discovery story, and no evidence yet of third-party producers.
+- Teams already doing the LLM-wiki pattern do it fine with `git clone` and a
+  `docs/` directory. `mdm knowledge add` beats that only via pinning,
+  update-checking, and the security scan — real but incremental wins.
+- The `audit` verb has nothing external to query; it can only diff local
+  hashes against the recorded ref until a registry exists.
+
+What *is* real today:
+
+1. **The validator.** A fast, dependency-free `mdm knowledge validate` (Go
+   binary vs. Google's Python tooling) that checks conformance and link
+   integrity fills a genuine gap — useful even to people who don't use mdm for
+   installation, and cheap to build. This is the highest confidence-to-effort
+   item in the whole spec.
+2. **The security scan.** Installing agent-bound markdown through a
+   hidden-character/prompt-smuggling scanner is a concrete, differentiated
+   safety win the moment anyone installs a bundle they didn't author.
+3. **Positioning and learning.** Being early to skills worked for mdm. If
+   knowledge-as-context keeps rising, the cheapest way to have an informed
+   opinion — and influence on the spec — is a working implementation we
+   dogfood ourselves.
+
+If OKF stalls, the sunk cost is bounded (see Exit criteria).
+
+## Value later — if the pattern holds
+
+- **Registry integration**: when an OKF registry or `.well-known/knowledge`
+  convention appears (mdm already speaks `.well-known/agent-skills` via
+  `internal/registry`), `find`/`audit` light up with real data.
+- **Agent wiring**: `mdm knowledge add` appending a managed pointer block to
+  AGENTS.md/CLAUDE.md (reusing `mdm rules` machinery) turns installed bundles
+  from files-on-disk into context agents actually load. This is likely the
+  step that makes the feature sticky.
+- **Team onboarding**: `mdm knowledge install` restoring an org's pinned
+  knowledge bundles in CI/onboarding, exactly like `mdm skills install`.
+- **Cross-format hedge**: if a competing knowledge format emerges, the
+  acquisition/lock/scan pipeline is format-agnostic; only discovery/validation
+  is OKF-specific (one module, not a rewrite).
+- **Doctor as knowledge CI**: link-rot and staleness checks (`timestamp` drift)
+  over a team's own bundle, run in CI — mdm becomes the lint step for the
+  knowledge itself, not just the installer.
+
+## Design
+
+### The experimental gate
+
+A named-feature gate (kubectl-alpha / GOEXPERIMENT precedent), not a single
+boolean, so future experiments reuse the rail.
+
+**`internal/experimental/`** (new, small):
+
+```go
+// Feature is a named experimental capability.
+type Feature string
+
+const Knowledge Feature = "knowledge"
+
+// Enabled reports whether f is active via the MDM_EXPERIMENTAL env var
+// (comma-separated names, or "all") or a persisted opt-in.
+func Enabled(f Feature) bool
+```
+
+**Activation paths:**
+
+1. `MDM_EXPERIMENTAL=knowledge` — ephemeral, CI-friendly, no state.
+2. `mdm experimental enable knowledge` — persists to an
+   `Experimental []string` field on the existing global lock file
+   (`SkillLockFile`), alongside the precedent set by `ConfiguredAgents` and
+   `DismissedPrompts`. Losing this field to an older binary's rewrite is
+   acceptable — it's a toggle, not data.
+
+**`mdm experimental` command group** (always visible):
+
+```
+mdm experimental
+├── list                 # available features, status, one-line description + spec link
+├── enable <feature>
+└── disable <feature>
+```
+
+**Registration behavior** (`BuildRootCmd`):
+
+- The `knowledge` command is always registered.
+- **Disabled**: `Hidden: true` (absent from help and shell completion) plus a
+  `PersistentPreRunE` that refuses with a pointer:
+  `knowledge is experimental — enable with 'mdm experimental enable knowledge' or MDM_EXPERIMENTAL=knowledge`.
+  Discoverable for people who heard about it; invisible to everyone else.
+- **Enabled**: visible with an `[experimental]` suffix in help text, and every
+  invocation prints one dim banner line:
+  `⚠ experimental: OKF support tracks spec v0.1 — commands and file formats may change`.
+
+**Stability contract**: README and release notes state that experimental
+features may change or be removed in any release, exempt from semver.
+
+### Command surface (behind the gate)
+
+```
+mdm knowledge
+├── add <source>         # install a bundle from GitHub, GitLab, URL, or local path
+│     --dir <path>       #   install root (default ./knowledge/)
+│     --ref <ref>        #   branch/tag/sha, as skills add
+│     --dry-run
+├── list                 # installed bundles: name, source, ref, doc count, spec version
+├── remove [bundles...]
+├── update [bundles...]  # re-fetch from recorded source+ref; re-scan; re-validate
+├── validate [path]      # OKF conformance check on an installed bundle or arbitrary dir
+├── init [name]          # scaffold a minimal conformant bundle (index.md + one concept)
+└── install              # restore all bundles from knowledge-lock.json (CI/onboarding)
+```
+
+Verbs, aliases, and flag conventions mirror `mdm skills` exactly — the group
+should feel like the same tool, not a bolted-on subproject.
+
+**Install destination.** Unlike skills, no per-agent knowledge directory
+convention exists. Default: `./knowledge/<bundle-name>/` at the project root,
+overridable with `--dir`. Project-scoped only for the experimental phase; a
+global scope can follow if a use case appears.
+
+### Lock file: separate by design
+
+Knowledge entries live in **`knowledge-lock.json`**, *not* in
+`skills-lock.json`.
+
+Rationale: `internal/lock` reads by unmarshaling into a fixed struct and
+**rewrites the file wholesale** on every change. Any older mdm binary (or a
+teammate on stable) touching skills would silently drop unknown keys — so
+experimental data in the shared file would be corruptible by non-experimental
+usage. A separate file gives the experiment zero blast radius and makes
+eventual graduation an explicit, versioned migration instead of an accretion.
+
+```json
+{
+  "version": 1,
+  "bundles": {
+    "acme-sales": {
+      "source": "github.com/acme/sales-knowledge",
+      "sourceType": "github",
+      "ref": "v2.1.0",
+      "installDir": "knowledge/acme-sales",
+      "specVersion": "0.1",
+      "contentHash": "sha256:…",
+      "installedAt": "2026-07-06T…",
+      "updatedAt": "2026-07-06T…"
+    }
+  }
+}
+```
+
+`specVersion` records which OKF revision the bundle conformed to at install
+time, so the validator can evolve with the standard and warn on drift.
+
+### `internal/okf/` (new)
+
+The only substantial new domain code:
+
+- **Discovery**: locate bundle roots in a fetched tree (heuristic: directories
+  of `.md` files with OKF frontmatter; explicit path wins over heuristics).
+- **Parsing**: frontmatter (`type` required; `title`, `description`,
+  `resource`, `tags`, `timestamp` reserved) — extend or mirror
+  `internal/skill`'s frontmatter handling rather than duplicating it.
+- **Validation**: per-document conformance, reserved-filename rules
+  (`index.md`, `log.md`), cross-link resolution (every relative markdown link
+  resolves inside the bundle), orphan detection (documents unreachable from
+  any `index.md`). Output modes: human (ANSI, like doctor) and `--json` for CI.
+
+Validation rules are versioned against the pinned SPEC.md revision; when the
+spec moves, rules update behind the gate with no compatibility burden.
+
+### Security scan is mandatory, not optional
+
+`add` and `update` run `internal/security`'s markdownscan over every document
+before copying, exactly as skills installs do (`commands/hidden_scan.go`).
+Findings block the install pending explicit confirmation. This is a headline
+behavior of the feature, not an implementation detail.
+
+### Doctor integration
+
+When (and only when) the gate is enabled, `mdm doctor` adds a knowledge
+section: lock-vs-disk hash drift, broken cross-links, missing `type` fields,
+stale `timestamp`s. When disabled, doctor's output is byte-identical to today.
+
+## Build plan
+
+Each PR lands green on the full pre-PR checklist (`gofmt -s`, `go test ./...`,
+`govulncheck`, `gocyclo -over 16`) and leaves `main` shippable — the gate is
+what makes incremental merging safe.
+
+| PR | Branch | Contents |
+|---|---|---|
+| 1 | `feat/experimental-gate` | `internal/experimental/`, `mdm experimental` group, `Experimental` field on `SkillLockFile`, hidden `knowledge` skeleton that refuses when disabled. Docs: `docs/experimental.md`. |
+| 2 | `feat/okf-validate` | `internal/okf/` parsing + validation, `mdm knowledge validate`, `init`. Pure-local, no network — the highest-value, lowest-risk slice ships first. |
+| 3 | `feat/knowledge-add` | `add`/`list`/`remove` wired through `source`/`git`/`blob` + security scan + `knowledge-lock.json`. |
+| 4 | `feat/knowledge-update` | `update`, `install`, doctor integration. |
+
+Defer (tracked, not built): agent wiring into AGENTS.md, registry integration,
+audit against external data, global scope.
+
+## Testing strategy
+
+Follow the repo's existing two-tier pattern.
+
+**Unit tests** (alongside packages):
+
+- `internal/experimental`: env-var parsing (single, list, `all`, empty),
+  persisted-toggle read, precedence.
+- `internal/okf`: table-driven over `testdata/` fixture bundles —
+  a conformant bundle, missing `type`, broken cross-link, orphaned doc,
+  reserved-filename violation, non-OKF markdown dir (discovery must decline).
+  Google's sample bundles (GA4 et al.) vendored as a conformance fixture so
+  spec drift shows up as a test failure.
+- `internal/lock`: knowledge lock round-trip; assert `skills-lock.json` is
+  untouched by knowledge operations.
+
+**End-to-end tests** (`tests/`, same harness as `cli_test.go` — build the real
+binary, exec it):
+
+- **Gate off** (default): `knowledge` absent from `mdm --help` and completion
+  output; invoking it exits non-zero with the enable hint; `mdm doctor` output
+  unchanged. These are the regression tests that keep the "graceful addition"
+  promise.
+- **Gate on** (`MDM_EXPERIMENTAL=knowledge` in the test env): `add` from a
+  local-path fixture bundle → files land under `knowledge/`, lock written,
+  banner printed; `validate` passes/fails the right fixtures with the right
+  exit codes; `remove` cleans files + lock; `install` restores from lock into
+  a fresh temp dir.
+- **Security**: a fixture bundle with hidden characters (mirroring
+  `tests/testdata/hidden-skill`) blocks the install.
+- **Cross-binary safety**: after a knowledge install, run a skills operation
+  and assert `knowledge-lock.json` survives byte-identical.
+
+**Not covered / accepted risk**: live GitHub/GitLab fetches (network) are
+exercised the same way skills' are today — via the shared `source`/`git` paths
+already under test; e2e fixtures use local paths.
+
+## Graduation criteria
+
+Promote out of experimental (visible by default, semver-covered, lock
+migration into the mainline) when all of:
+
+1. OKF publishes a stabilized revision (v1.0 or explicit stability statement),
+   or 6+ months pass with the spec stable in practice.
+2. Demonstrated third-party demand: non-trivial external usage, issues, or
+   conformant bundles in the wild that aren't Google's samples.
+3. The command surface has survived a full release cycle without breaking
+   changes.
+4. The install-destination and agent-wiring questions have settled answers.
+
+## Exit criteria (kill switch)
+
+If after ~2 quarters OKF shows no ecosystem traction, or a competing format
+clearly wins: delete `commands/knowledge.go`, `internal/okf/`, and the feature
+registry entry; keep `internal/experimental` (reusable rail) and the validator
+learnings. Because nothing was stable, removal is a minor release and a
+changelog line. Users' installed bundle *files* are never deleted by removal —
+only the tooling goes.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| OKF spec churns under us | Gate + `specVersion` pinning + versioned validator; we track, nothing breaks users |
+| OKF loses to a competing format | Pipeline is format-agnostic; only `internal/okf` is specific; exit criteria bound the cost |
+| Scope creep toward "knowledge platform" | Non-goals above; deferred list is tracked, not built |
+| Confusing skills vs. knowledge for users | Distinct noun, distinct docs page, help-text one-liners stating the difference |
+| Experimental state corrupted by stable binaries | Separate `knowledge-lock.json`; cross-binary safety e2e test |
+
+## Open questions
+
+1. **Bundle naming/identity**: derive from repo name, top-level `index.md`
+   title, or directory name? (Lean: directory name, sanitized, `--name`
+   override — matches skills.)
+2. **Multiple bundles per repo**: support `--bundle` filtering like `--skill`,
+   or one-bundle-per-add for v1? (Lean: discover all, prompt — matches skills
+   UX.)
+3. **Where validate's spec text lives**: vendor OKF's SPEC.md rules as code
+   with a pinned upstream commit hash, or fetch at runtime? (Lean: vendor;
+   `validate` must work offline.)

--- a/internal/experimental/experimental.go
+++ b/internal/experimental/experimental.go
@@ -1,0 +1,104 @@
+// Package experimental gates features that may change or be removed in any
+// release and are exempt from semantic versioning until they graduate.
+//
+// A feature is active when it is named in the MDM_EXPERIMENTAL environment
+// variable (comma-separated feature names, or "all"), or when it has been
+// persisted with `mdm experimental enable <feature>`.
+package experimental
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/sethcarney/mdm/internal/lock"
+)
+
+// Feature is a named experimental capability.
+type Feature string
+
+const Knowledge Feature = "knowledge"
+
+// EnvVar enables features for a single invocation without persisting
+// anything, e.g. MDM_EXPERIMENTAL=knowledge or MDM_EXPERIMENTAL=all.
+const EnvVar = "MDM_EXPERIMENTAL"
+
+type Info struct {
+	Feature     Feature
+	Description string
+	SpecURL     string
+}
+
+// All lists every known experimental feature, in display order.
+var All = []Info{
+	{
+		Feature:     Knowledge,
+		Description: "Manage OKF knowledge bundles (mdm knowledge)",
+		SpecURL:     "https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf",
+	},
+}
+
+func IsKnown(name string) bool {
+	for _, info := range All {
+		if string(info.Feature) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Enabled reports whether f is active via MDM_EXPERIMENTAL or a persisted opt-in.
+func Enabled(f Feature) bool {
+	return EnabledByEnv(f) || Persisted(f)
+}
+
+// EnabledByEnv reports whether f is named in the MDM_EXPERIMENTAL variable.
+func EnabledByEnv(f Feature) bool {
+	for _, part := range strings.Split(os.Getenv(EnvVar), ",") {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part == "all" || part == string(f) {
+			return true
+		}
+	}
+	return false
+}
+
+// Persisted reports whether f was enabled with `mdm experimental enable`.
+func Persisted(f Feature) bool {
+	for _, name := range lock.ReadSkillLock().Experimental {
+		if name == string(f) {
+			return true
+		}
+	}
+	return false
+}
+
+// Enable persists the opt-in for f in the global lock file.
+func Enable(f Feature) error {
+	lk := lock.ReadSkillLock()
+	for _, name := range lk.Experimental {
+		if name == string(f) {
+			return nil
+		}
+	}
+	lk.Experimental = append(lk.Experimental, string(f))
+	sort.Strings(lk.Experimental)
+	return lock.WriteSkillLock(lk)
+}
+
+// Disable removes the persisted opt-in for f. It does not affect
+// MDM_EXPERIMENTAL, which always wins.
+func Disable(f Feature) error {
+	lk := lock.ReadSkillLock()
+	kept := make([]string, 0, len(lk.Experimental))
+	for _, name := range lk.Experimental {
+		if name != string(f) {
+			kept = append(kept, name)
+		}
+	}
+	if len(kept) == len(lk.Experimental) {
+		return nil
+	}
+	lk.Experimental = kept
+	return lock.WriteSkillLock(lk)
+}

--- a/internal/experimental/experimental_test.go
+++ b/internal/experimental/experimental_test.go
@@ -1,0 +1,90 @@
+package experimental
+
+import "testing"
+
+// isolate points the global lock at a fresh temp dir so tests never read or
+// write the developer's real lock file.
+func isolate(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv(EnvVar, "")
+}
+
+func TestEnabledByEnv(t *testing.T) {
+	isolate(t)
+	cases := []struct {
+		env  string
+		want bool
+	}{
+		{"", false},
+		{"knowledge", true},
+		{"KNOWLEDGE", true},
+		{"  knowledge  ", true},
+		{"other,knowledge", true},
+		{"other, knowledge", true},
+		{"all", true},
+		{"ALL", true},
+		{"other", false},
+		{"knowledgeable", false},
+	}
+	for _, c := range cases {
+		t.Setenv(EnvVar, c.env)
+		if got := Enabled(Knowledge); got != c.want {
+			t.Errorf("MDM_EXPERIMENTAL=%q: Enabled(Knowledge)=%v, want %v", c.env, got, c.want)
+		}
+	}
+}
+
+func TestEnableDisablePersists(t *testing.T) {
+	isolate(t)
+
+	if Enabled(Knowledge) {
+		t.Fatal("expected knowledge to be disabled by default")
+	}
+	if err := Enable(Knowledge); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	if !Persisted(Knowledge) {
+		t.Fatal("expected knowledge to be persisted after Enable")
+	}
+	if !Enabled(Knowledge) {
+		t.Fatal("expected knowledge to be enabled after Enable")
+	}
+
+	// Enable is idempotent.
+	if err := Enable(Knowledge); err != nil {
+		t.Fatalf("second Enable: %v", err)
+	}
+
+	if err := Disable(Knowledge); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if Enabled(Knowledge) {
+		t.Fatal("expected knowledge to be disabled after Disable")
+	}
+
+	// Disable on an already-disabled feature is a no-op.
+	if err := Disable(Knowledge); err != nil {
+		t.Fatalf("second Disable: %v", err)
+	}
+}
+
+func TestEnvWinsOverDisable(t *testing.T) {
+	isolate(t)
+	t.Setenv(EnvVar, "knowledge")
+	if err := Disable(Knowledge); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if !Enabled(Knowledge) {
+		t.Fatal("expected MDM_EXPERIMENTAL to win over persisted disable")
+	}
+}
+
+func TestIsKnown(t *testing.T) {
+	if !IsKnown("knowledge") {
+		t.Error("expected knowledge to be a known feature")
+	}
+	if IsKnown("nonsense") {
+		t.Error("expected nonsense to be unknown")
+	}
+}

--- a/internal/lock/knowledge.go
+++ b/internal/lock/knowledge.go
@@ -1,0 +1,108 @@
+package lock
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// ──────────────────────────────────────────────────────────
+// Knowledge bundle lock (knowledge-lock.json, project scope)
+//
+// Knowledge entries deliberately live in their own file rather than in
+// skills-lock.json: the skill locks are read into fixed structs and
+// rewritten wholesale, so an older mdm binary touching skills would
+// silently drop unknown keys. A separate file keeps the experimental
+// knowledge feature invisible to — and incorruptible by — stable binaries.
+// ──────────────────────────────────────────────────────────
+
+const knowledgeLockVersion = 1
+
+type KnowledgeLockEntry struct {
+	Source      string `json:"source"`
+	SourceType  string `json:"sourceType"`
+	SourceURL   string `json:"sourceUrl,omitempty"`
+	Ref         string `json:"ref,omitempty"`
+	Subpath     string `json:"subpath,omitempty"`
+	InstallDir  string `json:"installDir"` // slash-separated, relative to the project root
+	SpecVersion string `json:"specVersion"`
+	ContentHash string `json:"contentHash,omitempty"`
+	InstalledAt string `json:"installedAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+type KnowledgeLockFile struct {
+	Version int                           `json:"version"`
+	Bundles map[string]KnowledgeLockEntry `json:"bundles"`
+}
+
+func GetKnowledgeLockPath(cwd string) string {
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	return filepath.Join(cwd, "knowledge-lock.json")
+}
+
+func ReadKnowledgeLock(cwd string) KnowledgeLockFile {
+	data, err := os.ReadFile(GetKnowledgeLockPath(cwd))
+	if err != nil {
+		return EmptyKnowledgeLock()
+	}
+	var lk KnowledgeLockFile
+	if err := json.Unmarshal(data, &lk); err != nil {
+		return EmptyKnowledgeLock()
+	}
+	if lk.Bundles == nil || lk.Version < knowledgeLockVersion {
+		return EmptyKnowledgeLock()
+	}
+	return lk
+}
+
+func WriteKnowledgeLock(lk KnowledgeLockFile, cwd string) error {
+	// Sort keys for deterministic output
+	sorted := KnowledgeLockFile{Version: lk.Version, Bundles: map[string]KnowledgeLockEntry{}}
+	keys := make([]string, 0, len(lk.Bundles))
+	for k := range lk.Bundles {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		sorted.Bundles[k] = lk.Bundles[k]
+	}
+	data, err := json.MarshalIndent(sorted, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(GetKnowledgeLockPath(cwd), append(data, '\n'), 0600)
+}
+
+func EmptyKnowledgeLock() KnowledgeLockFile {
+	return KnowledgeLockFile{Version: knowledgeLockVersion, Bundles: map[string]KnowledgeLockEntry{}}
+}
+
+func AddBundleToKnowledgeLock(name string, entry KnowledgeLockEntry, cwd string) error {
+	lk := ReadKnowledgeLock(cwd)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if existing, ok := lk.Bundles[name]; ok {
+		entry.InstalledAt = existing.InstalledAt
+	} else {
+		entry.InstalledAt = now
+	}
+	entry.UpdatedAt = now
+	lk.Bundles[name] = entry
+	return WriteKnowledgeLock(lk, cwd)
+}
+
+func RemoveBundleFromKnowledgeLock(name, cwd string) error {
+	lk := ReadKnowledgeLock(cwd)
+	if _, ok := lk.Bundles[name]; !ok {
+		return nil
+	}
+	delete(lk.Bundles, name)
+	if len(lk.Bundles) == 0 {
+		return os.Remove(GetKnowledgeLockPath(cwd))
+	}
+	return WriteKnowledgeLock(lk, cwd)
+}

--- a/internal/lock/knowledge_test.go
+++ b/internal/lock/knowledge_test.go
@@ -1,0 +1,92 @@
+package lock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKnowledgeLockRoundTrip(t *testing.T) {
+	cwd := t.TempDir()
+
+	if lk := ReadKnowledgeLock(cwd); len(lk.Bundles) != 0 {
+		t.Fatalf("expected empty lock, got %v", lk.Bundles)
+	}
+
+	entry := KnowledgeLockEntry{
+		Source:      "acme/sales-knowledge",
+		SourceType:  "github",
+		Ref:         "v1.0.0",
+		InstallDir:  "knowledge/sales",
+		SpecVersion: "0.1",
+		ContentHash: "sha256:abc",
+	}
+	if err := AddBundleToKnowledgeLock("sales", entry, cwd); err != nil {
+		t.Fatal(err)
+	}
+
+	lk := ReadKnowledgeLock(cwd)
+	got, ok := lk.Bundles["sales"]
+	if !ok {
+		t.Fatal("expected sales entry after add")
+	}
+	if got.Ref != "v1.0.0" || got.InstallDir != "knowledge/sales" || got.SpecVersion != "0.1" {
+		t.Errorf("unexpected entry: %+v", got)
+	}
+	if got.InstalledAt == "" || got.UpdatedAt == "" {
+		t.Error("expected timestamps to be set")
+	}
+
+	// Re-adding preserves InstalledAt.
+	entry.Ref = "v1.1.0"
+	if err := AddBundleToKnowledgeLock("sales", entry, cwd); err != nil {
+		t.Fatal(err)
+	}
+	updated := ReadKnowledgeLock(cwd).Bundles["sales"]
+	if updated.InstalledAt != got.InstalledAt {
+		t.Errorf("InstalledAt changed on update: %q vs %q", updated.InstalledAt, got.InstalledAt)
+	}
+	if updated.Ref != "v1.1.0" {
+		t.Errorf("Ref = %q, want v1.1.0", updated.Ref)
+	}
+}
+
+func TestKnowledgeLockRemoveDeletesFileWhenEmpty(t *testing.T) {
+	cwd := t.TempDir()
+	if err := AddBundleToKnowledgeLock("a", KnowledgeLockEntry{Source: "x", SourceType: "local", InstallDir: "knowledge/a", SpecVersion: "0.1"}, cwd); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveBundleFromKnowledgeLock("a", cwd); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "knowledge-lock.json")); !os.IsNotExist(err) {
+		t.Error("expected knowledge-lock.json to be deleted when the last bundle is removed")
+	}
+	// Removing a missing entry is a no-op.
+	if err := RemoveBundleFromKnowledgeLock("missing", cwd); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKnowledgeLockDoesNotTouchSkillLocks(t *testing.T) {
+	cwd := t.TempDir()
+	if err := AddSkillToLocalLock("my-skill", LocalSkillLockEntry{Source: "o/r", SourceType: "github"}, cwd); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(GetLocalLockPath(cwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddBundleToKnowledgeLock("sales", KnowledgeLockEntry{Source: "x", SourceType: "local", InstallDir: "knowledge/sales", SpecVersion: "0.1"}, cwd); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := os.ReadFile(GetLocalLockPath(cwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Error("knowledge lock operations must not modify skills-lock.json")
+	}
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -36,6 +36,7 @@ type SkillLockFile struct {
 	Skills           map[string]SkillLockEntry `json:"skills"`
 	Dismissed        DismissedPrompts          `json:"dismissed,omitempty"`
 	ConfiguredAgents []string                  `json:"configuredAgents,omitempty"`
+	Experimental     []string                  `json:"experimental,omitempty"`
 }
 
 func GetSkillLockPath() string {

--- a/internal/okf/discover.go
+++ b/internal/okf/discover.go
@@ -1,0 +1,62 @@
+package okf
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func hasIndexMd(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, "index.md"))
+	return err == nil && !info.IsDir()
+}
+
+func hasMarkdown(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || found {
+			return filepath.SkipAll
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if p != dir && (skipDirs[name] || strings.HasPrefix(name, ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.EqualFold(filepath.Ext(name), ".md") {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// FindBundleRoots locates OKF bundle roots under root. A bundle root is a
+// directory containing an index.md whose ancestors contain none (nested
+// index.md files belong to the same bundle). When no index.md exists
+// anywhere, root itself is the bundle if it holds any markdown at all —
+// index files are recommended by the spec but not required.
+func FindBundleRoots(root string) []string {
+	var roots []string
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if p != root && (skipDirs[name] || strings.HasPrefix(name, ".")) {
+			return filepath.SkipDir
+		}
+		if hasIndexMd(p) {
+			roots = append(roots, p)
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if len(roots) == 0 && hasMarkdown(root) {
+		return []string{root}
+	}
+	return roots
+}

--- a/internal/okf/discover_test.go
+++ b/internal/okf/discover_test.go
@@ -1,0 +1,92 @@
+package okf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFindBundleRootsNested(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "bundles", "ga4", "index.md"), "# GA4\n")
+	writeFile(t, filepath.Join(root, "bundles", "ga4", "tables", "index.md"), "# nested index belongs to ga4\n")
+	writeFile(t, filepath.Join(root, "bundles", "bitcoin", "index.md"), "# Bitcoin\n")
+	writeFile(t, filepath.Join(root, "README.md"), "not a bundle doc\n")
+
+	roots := FindBundleRoots(root)
+	if len(roots) != 2 {
+		t.Fatalf("expected 2 bundle roots, got %v", roots)
+	}
+	for _, r := range roots {
+		base := filepath.Base(r)
+		if base != "ga4" && base != "bitcoin" {
+			t.Errorf("unexpected bundle root %q", r)
+		}
+	}
+}
+
+func TestFindBundleRootsIndexAtTop(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "index.md"), "# top\n")
+	writeFile(t, filepath.Join(root, "sub", "index.md"), "# sub index belongs to the top bundle\n")
+
+	roots := FindBundleRoots(root)
+	if len(roots) != 1 || roots[0] != root {
+		t.Fatalf("expected [%s], got %v", root, roots)
+	}
+}
+
+func TestFindBundleRootsNoIndexFallsBackToRoot(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "concepts", "a.md"), "---\ntype: Concept\n---\n")
+
+	roots := FindBundleRoots(root)
+	if len(roots) != 1 || roots[0] != root {
+		t.Fatalf("expected [%s], got %v", root, roots)
+	}
+}
+
+func TestFindBundleRootsEmpty(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "data.json"), "{}")
+
+	if roots := FindBundleRoots(root); len(roots) != 0 {
+		t.Fatalf("expected no bundle roots, got %v", roots)
+	}
+}
+
+func TestHashBundleDirDetectsChanges(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "index.md"), "# v1\n")
+
+	h1, err := HashBundleDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := HashBundleDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Errorf("hash not deterministic: %s vs %s", h1, h2)
+	}
+
+	writeFile(t, filepath.Join(root, "index.md"), "# v2\n")
+	h3, err := HashBundleDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h3 == h1 {
+		t.Error("expected hash to change when content changes")
+	}
+}

--- a/internal/okf/hash.go
+++ b/internal/okf/hash.go
@@ -1,0 +1,52 @@
+package okf
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HashBundleDir returns a deterministic sha256 over every file's relative
+// path and contents, used to detect drift between an installed bundle and
+// its lock entry. WalkDir visits files in lexical order, which makes the
+// digest stable across runs and platforms.
+func HashBundleDir(root string) (string, error) {
+	h := sha256.New()
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if p != root && (skipDirs[name] || strings.HasPrefix(name, ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		io.WriteString(h, filepath.ToSlash(rel))
+		h.Write([]byte{0})
+		f, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(h, f)
+		f.Close()
+		if err != nil {
+			return err
+		}
+		h.Write([]byte{0})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil)), nil
+}

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -1,0 +1,185 @@
+// Package okf parses and validates Open Knowledge Format bundles —
+// directories of markdown documents with YAML frontmatter where each file is
+// one concept and documents cross-link with ordinary markdown links.
+//
+// This implementation tracks OKF spec v0.1:
+// https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf
+package okf
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sethcarney/mdm/internal/skill"
+)
+
+// Reserved filenames per the OKF spec: index.md provides hierarchical
+// navigation, log.md holds chronological change history. Both are
+// navigational and exempt from the required `type` frontmatter field.
+var reservedFilenames = map[string]bool{
+	"index.md": true,
+	"log.md":   true,
+}
+
+// Link is a markdown link found in a document body.
+type Link struct {
+	Target string // raw link target as written
+	Line   int    // 1-indexed line in the file
+}
+
+// Document is one markdown file in a bundle. RelPath is slash-separated and
+// relative to the bundle root; per the spec it is the concept's identity.
+type Document struct {
+	RelPath     string
+	Type        string
+	Title       string
+	Description string
+	Resource    string
+	Tags        []string
+	Timestamp   string
+	Links       []Link
+	Body        string
+}
+
+// Reserved reports whether the document is a reserved navigational file.
+func (d *Document) Reserved() bool {
+	return reservedFilenames[path.Base(d.RelPath)]
+}
+
+// Bundle is a parsed OKF bundle.
+type Bundle struct {
+	Root string
+	Docs []*Document
+}
+
+var skipDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"__pycache__":  true,
+}
+
+// LoadBundle parses every markdown document under root into a Bundle.
+func LoadBundle(root string) (*Bundle, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", root)
+	}
+
+	b := &Bundle{Root: root}
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if p != root && (skipDirs[name] || strings.HasPrefix(name, ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.EqualFold(filepath.Ext(name), ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		doc, err := parseDocument(p, filepath.ToSlash(rel))
+		if err != nil {
+			return err
+		}
+		b.Docs = append(b.Docs, doc)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(b.Docs, func(i, j int) bool { return b.Docs[i].RelPath < b.Docs[j].RelPath })
+	return b, nil
+}
+
+// linkRe matches inline markdown links and images: [text](target) and
+// ![alt](target), capturing the target up to whitespace or the closing paren.
+// Reference-style links are not resolved.
+var linkRe = regexp.MustCompile(`!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)`)
+
+func parseDocument(fullPath, relPath string) (*Document, error) {
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+	data, body := skill.ParseFrontmatter(string(content))
+
+	doc := &Document{
+		RelPath:     relPath,
+		Type:        stringField(data, "type"),
+		Title:       stringField(data, "title"),
+		Description: stringField(data, "description"),
+		Resource:    stringField(data, "resource"),
+		Tags:        stringSliceField(data, "tags"),
+		Timestamp:   timestampField(data),
+		Body:        body,
+	}
+
+	// Frontmatter lines precede the body; link line numbers must be
+	// file-relative, so offset by the number of lines the frontmatter consumed.
+	offset := strings.Count(string(content), "\n") - strings.Count(body, "\n")
+	for i, line := range strings.Split(body, "\n") {
+		for _, m := range linkRe.FindAllStringSubmatch(line, -1) {
+			doc.Links = append(doc.Links, Link{Target: m[1], Line: offset + i + 1})
+		}
+	}
+	return doc, nil
+}
+
+func stringField(data map[string]interface{}, key string) string {
+	if v, ok := data[key]; ok {
+		switch s := v.(type) {
+		case string:
+			return s
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	return ""
+}
+
+// timestampField returns the timestamp frontmatter value as an RFC 3339
+// string. yaml.v3 decodes unquoted ISO 8601 values into time.Time, so both
+// quoted and unquoted timestamps normalize to the same representation.
+func timestampField(data map[string]interface{}) string {
+	if v, ok := data["timestamp"]; ok {
+		if t, ok := v.(time.Time); ok {
+			return t.UTC().Format(time.RFC3339)
+		}
+	}
+	return stringField(data, "timestamp")
+}
+
+func stringSliceField(data map[string]interface{}, key string) []string {
+	v, ok := data[key]
+	if !ok {
+		return nil
+	}
+	items, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	var result []string
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -1,0 +1,141 @@
+package okf
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func loadFixture(t *testing.T, name string) *Bundle {
+	t.Helper()
+	b, err := LoadBundle(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("LoadBundle(%s): %v", name, err)
+	}
+	return b
+}
+
+func rulesOf(issues []Issue) map[string]int {
+	counts := map[string]int{}
+	for _, issue := range issues {
+		counts[issue.Rule]++
+	}
+	return counts
+}
+
+func TestLoadBundleParsesDocuments(t *testing.T) {
+	b := loadFixture(t, "valid-bundle")
+	if len(b.Docs) != 3 {
+		t.Fatalf("expected 3 documents, got %d", len(b.Docs))
+	}
+
+	var orders *Document
+	for _, d := range b.Docs {
+		if d.RelPath == "tables/orders.md" {
+			orders = d
+		}
+	}
+	if orders == nil {
+		t.Fatal("expected tables/orders.md in bundle")
+	}
+	if orders.Type != "BigQuery Table" {
+		t.Errorf("type = %q, want %q", orders.Type, "BigQuery Table")
+	}
+	if orders.Title != "Orders" {
+		t.Errorf("title = %q, want %q", orders.Title, "Orders")
+	}
+	if len(orders.Tags) != 2 || orders.Tags[0] != "sales" {
+		t.Errorf("tags = %v, want [sales revenue]", orders.Tags)
+	}
+	if orders.Timestamp != "2026-05-28T14:30:00Z" {
+		t.Errorf("timestamp = %q, want 2026-05-28T14:30:00Z", orders.Timestamp)
+	}
+	// Two markdown links + one external in the body; all are captured raw.
+	if len(orders.Links) != 2 {
+		t.Errorf("links = %v, want 2 entries", orders.Links)
+	}
+}
+
+func TestValidateCleanBundle(t *testing.T) {
+	issues := Validate(loadFixture(t, "valid-bundle"))
+	if len(issues) != 0 {
+		t.Errorf("expected no issues for valid bundle, got %v", issues)
+	}
+}
+
+func TestValidateMissingType(t *testing.T) {
+	issues := Validate(loadFixture(t, "missing-type"))
+	if rulesOf(issues)["missing-type"] != 1 {
+		t.Errorf("expected one missing-type error, got %v", issues)
+	}
+	if !HasErrors(issues) {
+		t.Error("expected HasErrors to be true")
+	}
+	for _, issue := range issues {
+		if issue.Rule == "missing-type" && issue.File != "concepts/no-type.md" {
+			t.Errorf("missing-type anchored to %q, want concepts/no-type.md", issue.File)
+		}
+	}
+}
+
+func TestValidateBrokenLink(t *testing.T) {
+	issues := Validate(loadFixture(t, "broken-link"))
+	if rulesOf(issues)["broken-link"] != 1 {
+		t.Errorf("expected one broken-link error, got %v", issues)
+	}
+}
+
+func TestValidateEscapingLink(t *testing.T) {
+	issues := Validate(loadFixture(t, "escape-link"))
+	if rulesOf(issues)["link-escapes-bundle"] != 1 {
+		t.Errorf("expected one link-escapes-bundle error, got %v", issues)
+	}
+}
+
+func TestValidateOrphan(t *testing.T) {
+	issues := Validate(loadFixture(t, "orphan"))
+	counts := rulesOf(issues)
+	if counts["orphaned-document"] != 1 {
+		t.Errorf("expected one orphaned-document warning, got %v", issues)
+	}
+	if counts["invalid-timestamp"] != 1 {
+		t.Errorf("expected one invalid-timestamp warning, got %v", issues)
+	}
+	// Warnings alone must not fail validation.
+	if HasErrors(issues) {
+		t.Errorf("expected warnings only, got %v", issues)
+	}
+}
+
+func TestValidateEmptyBundle(t *testing.T) {
+	issues := Validate(&Bundle{Root: t.TempDir()})
+	if rulesOf(issues)["empty-bundle"] != 1 || !HasErrors(issues) {
+		t.Errorf("expected empty-bundle error, got %v", issues)
+	}
+}
+
+func TestLoadBundleMissingDir(t *testing.T) {
+	if _, err := LoadBundle(filepath.Join("testdata", "does-not-exist")); err == nil {
+		t.Error("expected error for missing directory")
+	}
+}
+
+func TestResolveLink(t *testing.T) {
+	cases := []struct {
+		from, target string
+		want         string
+		inside       bool
+	}{
+		{"index.md", "tables/orders.md", "tables/orders.md", true},
+		{"tables/orders.md", "../metrics/wau.md", "metrics/wau.md", true},
+		{"tables/orders.md", "/metrics/wau.md", "metrics/wau.md", true},
+		{"tables/orders.md", "/metrics/wau.md#definition", "metrics/wau.md", true},
+		{"index.md", "../outside.md", "../outside.md", false},
+		{"a/b/c.md", "../../../x.md", "../x.md", false},
+	}
+	for _, c := range cases {
+		got, inside := resolveLink(c.from, c.target)
+		if got != c.want || inside != c.inside {
+			t.Errorf("resolveLink(%q, %q) = (%q, %v), want (%q, %v)", c.from, c.target, got, inside, c.want, c.inside)
+		}
+	}
+}

--- a/internal/okf/testdata/broken-link/concepts/exists.md
+++ b/internal/okf/testdata/broken-link/concepts/exists.md
@@ -1,0 +1,6 @@
+---
+type: Concept
+title: Exists
+---
+
+A valid concept document.

--- a/internal/okf/testdata/broken-link/index.md
+++ b/internal/okf/testdata/broken-link/index.md
@@ -1,0 +1,6 @@
+---
+title: Bundle with a broken link
+---
+
+- [Exists](concepts/exists.md)
+- [Does not exist](concepts/missing.md)

--- a/internal/okf/testdata/escape-link/index.md
+++ b/internal/okf/testdata/escape-link/index.md
@@ -1,0 +1,5 @@
+---
+title: Bundle with a link that escapes the bundle root
+---
+
+- [Outside](../outside.md)

--- a/internal/okf/testdata/missing-type/concepts/no-type.md
+++ b/internal/okf/testdata/missing-type/concepts/no-type.md
@@ -1,0 +1,5 @@
+---
+title: Missing the required type field
+---
+
+This concept document has frontmatter but no `type`.

--- a/internal/okf/testdata/missing-type/index.md
+++ b/internal/okf/testdata/missing-type/index.md
@@ -1,0 +1,5 @@
+---
+title: Bundle with a nonconformant document
+---
+
+- [No type](concepts/no-type.md)

--- a/internal/okf/testdata/orphan/index.md
+++ b/internal/okf/testdata/orphan/index.md
@@ -1,0 +1,5 @@
+---
+title: Bundle with an orphaned document
+---
+
+- [Linked](linked.md)

--- a/internal/okf/testdata/orphan/linked.md
+++ b/internal/okf/testdata/orphan/linked.md
@@ -1,0 +1,6 @@
+---
+type: Concept
+title: Linked
+---
+
+Reachable from the index.

--- a/internal/okf/testdata/orphan/orphan.md
+++ b/internal/okf/testdata/orphan/orphan.md
@@ -1,0 +1,7 @@
+---
+type: Concept
+title: Orphan
+timestamp: not-a-timestamp
+---
+
+Nothing links here.

--- a/internal/okf/testdata/valid-bundle/index.md
+++ b/internal/okf/testdata/valid-bundle/index.md
@@ -1,0 +1,9 @@
+---
+title: Sales knowledge
+description: Curated context for the sales data domain.
+---
+
+# Sales
+
+- [Orders](/tables/orders.md)
+- [Weekly active users](metrics/wau.md)

--- a/internal/okf/testdata/valid-bundle/metrics/wau.md
+++ b/internal/okf/testdata/valid-bundle/metrics/wau.md
@@ -1,0 +1,10 @@
+---
+type: Metric
+title: Weekly active users
+description: Distinct customers with at least one order in a trailing 7-day window.
+tags: [growth]
+---
+
+# Definition
+
+Computed from [orders](../tables/orders.md) grouped by week.

--- a/internal/okf/testdata/valid-bundle/tables/orders.md
+++ b/internal/okf/testdata/valid-bundle/tables/orders.md
@@ -1,0 +1,19 @@
+---
+type: BigQuery Table
+title: Orders
+description: One row per completed customer order.
+resource: https://console.cloud.google.com/bigquery?p=acme&d=sales&t=orders
+tags: [sales, revenue]
+timestamp: 2026-05-28T14:30:00Z
+---
+
+# Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `order_id` | STRING | Globally unique order identifier. |
+
+# Related
+
+Used by [weekly active users](/metrics/wau.md). See the
+[console](https://console.cloud.google.com/) for live data.

--- a/internal/okf/validate.go
+++ b/internal/okf/validate.go
@@ -1,0 +1,176 @@
+package okf
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"time"
+)
+
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Issue is one validation finding, anchored to a document when applicable.
+type Issue struct {
+	File     string   `json:"file,omitempty"`
+	Line     int      `json:"line,omitempty"`
+	Severity Severity `json:"severity"`
+	Rule     string   `json:"rule"`
+	Message  string   `json:"message"`
+}
+
+// Validate checks a bundle against OKF v0.1 conformance rules plus link
+// integrity. Errors indicate spec violations; warnings indicate likely
+// mistakes that the spec does not forbid.
+func Validate(b *Bundle) []Issue {
+	if len(b.Docs) == 0 {
+		return []Issue{{
+			Severity: SeverityError,
+			Rule:     "empty-bundle",
+			Message:  "no markdown documents found in bundle",
+		}}
+	}
+	var issues []Issue
+	issues = append(issues, checkFrontmatter(b)...)
+	issues = append(issues, checkLinks(b)...)
+	issues = append(issues, checkOrphans(b)...)
+	return issues
+}
+
+// HasErrors reports whether any issue has error severity.
+func HasErrors(issues []Issue) bool {
+	for _, issue := range issues {
+		if issue.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// checkFrontmatter enforces the required `type` field on concept documents
+// (reserved navigational files are exempt) and warns on malformed timestamps.
+func checkFrontmatter(b *Bundle) []Issue {
+	var issues []Issue
+	for _, doc := range b.Docs {
+		if doc.Type == "" && !doc.Reserved() {
+			issues = append(issues, Issue{
+				File:     doc.RelPath,
+				Severity: SeverityError,
+				Rule:     "missing-type",
+				Message:  "frontmatter is missing the required `type` field",
+			})
+		}
+		if doc.Timestamp != "" {
+			if _, err := time.Parse(time.RFC3339, doc.Timestamp); err != nil {
+				issues = append(issues, Issue{
+					File:     doc.RelPath,
+					Severity: SeverityWarning,
+					Rule:     "invalid-timestamp",
+					Message:  fmt.Sprintf("timestamp %q is not ISO 8601 / RFC 3339", doc.Timestamp),
+				})
+			}
+		}
+	}
+	return issues
+}
+
+// isExternalLink reports whether the target points outside the bundle by
+// scheme rather than by path (URLs, mail links, in-page anchors).
+func isExternalLink(target string) bool {
+	return strings.Contains(target, "://") ||
+		strings.HasPrefix(target, "mailto:") ||
+		strings.HasPrefix(target, "#")
+}
+
+// resolveLink normalizes a link target to a slash-separated path relative to
+// the bundle root. Targets with a leading slash are root-relative per the OKF
+// examples; everything else resolves against the linking document's directory.
+// The second return is false when the target escapes the bundle root.
+func resolveLink(fromRelPath, target string) (string, bool) {
+	target = strings.SplitN(target, "#", 2)[0]
+	var resolved string
+	if strings.HasPrefix(target, "/") {
+		resolved = path.Clean(strings.TrimPrefix(target, "/"))
+	} else {
+		resolved = path.Join(path.Dir(fromRelPath), target)
+	}
+	if resolved == ".." || strings.HasPrefix(resolved, "../") {
+		return resolved, false
+	}
+	return resolved, true
+}
+
+// checkLinks verifies that every markdown-to-markdown link resolves to a
+// document inside the bundle.
+func checkLinks(b *Bundle) []Issue {
+	docSet := make(map[string]bool, len(b.Docs))
+	for _, doc := range b.Docs {
+		docSet[doc.RelPath] = true
+	}
+	var issues []Issue
+	for _, doc := range b.Docs {
+		for _, link := range doc.Links {
+			if isExternalLink(link.Target) || !strings.HasSuffix(strings.SplitN(link.Target, "#", 2)[0], ".md") {
+				continue
+			}
+			resolved, inside := resolveLink(doc.RelPath, link.Target)
+			if !inside {
+				issues = append(issues, Issue{
+					File:     doc.RelPath,
+					Line:     link.Line,
+					Severity: SeverityError,
+					Rule:     "link-escapes-bundle",
+					Message:  fmt.Sprintf("link %q resolves outside the bundle", link.Target),
+				})
+				continue
+			}
+			if !docSet[resolved] {
+				issues = append(issues, Issue{
+					File:     doc.RelPath,
+					Line:     link.Line,
+					Severity: SeverityError,
+					Rule:     "broken-link",
+					Message:  fmt.Sprintf("link %q does not resolve to a document in the bundle", link.Target),
+				})
+			}
+		}
+	}
+	return issues
+}
+
+// checkOrphans warns about concept documents that no other document links to.
+// Reserved navigational files are exempt: index.md files are entry points and
+// log.md files are append-only histories.
+func checkOrphans(b *Bundle) []Issue {
+	if len(b.Docs) == 1 {
+		return nil
+	}
+	incoming := map[string]bool{}
+	for _, doc := range b.Docs {
+		for _, link := range doc.Links {
+			if isExternalLink(link.Target) {
+				continue
+			}
+			if resolved, inside := resolveLink(doc.RelPath, link.Target); inside && resolved != doc.RelPath {
+				incoming[resolved] = true
+			}
+		}
+	}
+	var issues []Issue
+	for _, doc := range b.Docs {
+		if doc.Reserved() || incoming[doc.RelPath] {
+			continue
+		}
+		issues = append(issues, Issue{
+			File:     doc.RelPath,
+			Severity: SeverityWarning,
+			Rule:     "orphaned-document",
+			Message:  "no other document links to this concept",
+		})
+	}
+	return issues
+}

--- a/tests/knowledge_test.go
+++ b/tests/knowledge_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -93,6 +95,66 @@ func TestExperimentalEnableUnknownFeature(t *testing.T) {
 	}
 	if !strings.Contains(stdout+stderr, "unknown experimental feature") {
 		t.Errorf("expected unknown-feature error, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+// okfFixturePath returns the path to a fixture bundle in internal/okf/testdata.
+func okfFixturePath(t *testing.T, name string) string {
+	t.Helper()
+	root, err := findModRoot()
+	if err != nil {
+		t.Fatalf("finding module root: %v", err)
+	}
+	return filepath.Join(root, "internal", "okf", "testdata", name)
+}
+
+func TestKnowledgeInitValidateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	_, stderr, code := runMdmInDir(t, dir, env, "knowledge", "init", "my-bundle")
+	if code != 0 {
+		t.Fatalf("knowledge init exited %d: %s", code, stderr)
+	}
+
+	stdout, stderr, code := runMdmInDir(t, dir, env, "knowledge", "validate", "my-bundle")
+	if code != 0 {
+		t.Fatalf("scaffolded bundle should validate cleanly, exited %d:\n%s%s", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "no issues") {
+		t.Errorf("expected 'no issues' in validate output, got: %q", stdout)
+	}
+}
+
+func TestKnowledgeValidateFailsOnBrokenBundle(t *testing.T) {
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+	stdout, stderr, code := runMdmInDir(t, t.TempDir(), env, "knowledge", "validate", okfFixturePath(t, "broken-link"))
+	if code == 0 {
+		t.Fatal("expected non-zero exit for bundle with broken links")
+	}
+	if !strings.Contains(stdout+stderr, "broken-link") {
+		t.Errorf("expected broken-link rule in output, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestKnowledgeValidateJSON(t *testing.T) {
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+	stdout, stderr, code := runMdmInDir(t, t.TempDir(), env, "knowledge", "validate", "--json", okfFixturePath(t, "valid-bundle"))
+	if code != 0 {
+		t.Fatalf("validate --json exited %d: %s", code, stderr)
+	}
+	var report struct {
+		Documents int `json:"documents"`
+		Errors    int `json:"errors"`
+		Issues    []struct {
+			Rule string `json:"rule"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout)
+	}
+	if report.Documents != 3 || report.Errors != 0 || len(report.Issues) != 0 {
+		t.Errorf("unexpected report: %+v", report)
 	}
 }
 

--- a/tests/knowledge_test.go
+++ b/tests/knowledge_test.go
@@ -1,0 +1,108 @@
+package tests_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// freshEnv builds an isolated environment with a throwaway HOME and
+// XDG_STATE_HOME so tests never read or write the developer's real global
+// lock file. Extra entries are appended as-is.
+func freshEnv(t *testing.T, extra ...string) []string {
+	t.Helper()
+	return append(isolatedEnv(t.TempDir(), t.TempDir()), extra...)
+}
+
+func TestKnowledgeHiddenWhenGateOff(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := runMdmInDir(t, dir, freshEnv(t), "--help")
+	if code != 0 {
+		t.Fatalf("mdm --help exited %d", code)
+	}
+	if strings.Contains(stdout, "knowledge") {
+		t.Errorf("knowledge should be hidden from --help while the experimental gate is off, got: %q", stdout)
+	}
+}
+
+func TestKnowledgeRefusesWhenGateOff(t *testing.T) {
+	dir := t.TempDir()
+	stdout, stderr, code := runMdmInDir(t, dir, freshEnv(t), "knowledge")
+	if code == 0 {
+		t.Fatal("expected non-zero exit while the experimental gate is off")
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "mdm experimental enable knowledge") {
+		t.Errorf("expected refusal to point at the enable command, got stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(combined, "MDM_EXPERIMENTAL") {
+		t.Errorf("expected refusal to mention the env var, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestKnowledgeEnabledViaEnv(t *testing.T) {
+	dir := t.TempDir()
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	_, stderr, code := runMdmInDir(t, dir, env, "knowledge")
+	if code != 0 {
+		t.Fatalf("mdm knowledge exited %d with gate on: %s", code, stderr)
+	}
+	if !strings.Contains(stderr, "experimental") {
+		t.Errorf("expected experimental banner on stderr, got: %q", stderr)
+	}
+
+	stdout, _, code := runMdmInDir(t, dir, env, "--help")
+	if code != 0 {
+		t.Fatalf("mdm --help exited %d", code)
+	}
+	if !strings.Contains(stdout, "knowledge") {
+		t.Errorf("expected knowledge in --help with gate on, got: %q", stdout)
+	}
+}
+
+func TestExperimentalEnableDisableRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	env := freshEnv(t)
+
+	_, stderr, code := runMdmInDir(t, dir, env, "experimental", "enable", "knowledge")
+	if code != 0 {
+		t.Fatalf("experimental enable exited %d: %s", code, stderr)
+	}
+
+	_, stderr, code = runMdmInDir(t, dir, env, "knowledge")
+	if code != 0 {
+		t.Fatalf("mdm knowledge should run after enable, exited %d: %s", code, stderr)
+	}
+
+	_, stderr, code = runMdmInDir(t, dir, env, "experimental", "disable", "knowledge")
+	if code != 0 {
+		t.Fatalf("experimental disable exited %d: %s", code, stderr)
+	}
+
+	_, _, code = runMdmInDir(t, dir, env, "knowledge")
+	if code == 0 {
+		t.Fatal("expected refusal after disable")
+	}
+}
+
+func TestExperimentalEnableUnknownFeature(t *testing.T) {
+	dir := t.TempDir()
+	stdout, stderr, code := runMdmInDir(t, dir, freshEnv(t), "experimental", "enable", "nonsense")
+	if code == 0 {
+		t.Fatal("expected non-zero exit for unknown feature")
+	}
+	if !strings.Contains(stdout+stderr, "unknown experimental feature") {
+		t.Errorf("expected unknown-feature error, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestExperimentalList(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := runMdmInDir(t, dir, freshEnv(t), "experimental", "list")
+	if code != 0 {
+		t.Fatalf("experimental list exited %d", code)
+	}
+	if !strings.Contains(stdout, "knowledge") {
+		t.Errorf("expected knowledge in experimental list, got: %q", stdout)
+	}
+}

--- a/tests/knowledge_test.go
+++ b/tests/knowledge_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -155,6 +156,151 @@ func TestKnowledgeValidateJSON(t *testing.T) {
 	}
 	if report.Documents != 3 || report.Errors != 0 || len(report.Issues) != 0 {
 		t.Errorf("unexpected report: %+v", report)
+	}
+}
+
+// writeSourceBundle creates a small valid OKF bundle to install from.
+func writeSourceBundle(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "concepts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	index := "---\ntitle: Fixture\n---\n\n- [Thing](concepts/thing.md)\n"
+	concept := "---\ntype: Concept\ntitle: Thing\n---\n\nA thing.\n"
+	if err := os.WriteFile(filepath.Join(dir, "index.md"), []byte(index), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "concepts", "thing.md"), []byte(concept), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKnowledgeAddListRemoveLocal(t *testing.T) {
+	project := t.TempDir()
+	src := filepath.Join(project, "src-bundle")
+	writeSourceBundle(t, src)
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	// add
+	stdout, stderr, code := runMdmInDir(t, project, env, "knowledge", "add", "./src-bundle", "-y")
+	if code != 0 {
+		t.Fatalf("knowledge add exited %d:\n%s%s", code, stdout, stderr)
+	}
+	installed := filepath.Join(project, "knowledge", "src-bundle", "index.md")
+	if _, err := os.Stat(installed); err != nil {
+		t.Fatalf("expected installed bundle at %s: %v", installed, err)
+	}
+	lockPath := filepath.Join(project, "knowledge-lock.json")
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("expected knowledge-lock.json: %v", err)
+	}
+	for _, want := range []string{"src-bundle", "specVersion", "contentHash", "knowledge/src-bundle"} {
+		if !strings.Contains(string(lockData), want) {
+			t.Errorf("expected %q in knowledge-lock.json, got:\n%s", want, lockData)
+		}
+	}
+
+	// list
+	stdout, stderr, code = runMdmInDir(t, project, env, "knowledge", "list")
+	if code != 0 {
+		t.Fatalf("knowledge list exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "src-bundle") || !strings.Contains(stdout, "2 document(s)") {
+		t.Errorf("unexpected list output: %q", stdout)
+	}
+
+	// remove
+	_, stderr, code = runMdmInDir(t, project, env, "knowledge", "remove", "src-bundle", "-y")
+	if code != 0 {
+		t.Fatalf("knowledge remove exited %d: %s", code, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(project, "knowledge", "src-bundle")); !os.IsNotExist(err) {
+		t.Error("expected installed bundle directory to be removed")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Error("expected knowledge-lock.json to be removed with the last bundle")
+	}
+}
+
+func TestKnowledgeAddDryRunWritesNothing(t *testing.T) {
+	project := t.TempDir()
+	src := filepath.Join(project, "src-bundle")
+	writeSourceBundle(t, src)
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	stdout, stderr, code := runMdmInDir(t, project, env, "knowledge", "add", "./src-bundle", "-y", "--dry-run")
+	if code != 0 {
+		t.Fatalf("knowledge add --dry-run exited %d:\n%s%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(project, "knowledge")); !os.IsNotExist(err) {
+		t.Error("dry run must not create the knowledge directory")
+	}
+	if _, err := os.Stat(filepath.Join(project, "knowledge-lock.json")); !os.IsNotExist(err) {
+		t.Error("dry run must not write knowledge-lock.json")
+	}
+}
+
+func TestKnowledgeAddBlocksHiddenChars(t *testing.T) {
+	project := t.TempDir()
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+	root, err := findModRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := filepath.Join(root, "tests", "testdata", "hidden-knowledge")
+
+	stdout, stderr, code := runMdmInDir(t, project, env, "knowledge", "add", fixture, "-y")
+	combined := stdout + stderr
+	if code == 0 {
+		t.Fatalf("expected hidden character scan to block install:\n%s", combined)
+	}
+	if !strings.Contains(combined, "Hidden character") {
+		t.Errorf("expected hidden character finding, got:\n%s", combined)
+	}
+	if _, err := os.Stat(filepath.Join(project, "knowledge-lock.json")); !os.IsNotExist(err) {
+		t.Error("blocked install must not write knowledge-lock.json")
+	}
+}
+
+func TestKnowledgeLockSurvivesSkillsOperations(t *testing.T) {
+	project := t.TempDir()
+	src := filepath.Join(project, "src-bundle")
+	writeSourceBundle(t, src)
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	if _, stderr, code := runMdmInDir(t, project, env, "knowledge", "add", "./src-bundle", "-y"); code != 0 {
+		t.Fatalf("knowledge add exited %d: %s", code, stderr)
+	}
+	lockPath := filepath.Join(project, "knowledge-lock.json")
+	before, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A skills operation that rewrites skills-lock.json must leave the
+	// knowledge lock byte-identical.
+	skillDir := filepath.Join(project, "my-skill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillMd := "---\nname: my-skill\ndescription: fixture skill\n---\n\n# my-skill\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillMd), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if stdout, stderr, code := runMdmInDir(t, project, env, "skills", "add", "./my-skill", "-p", "-y", "-a", "claude-code"); code != 0 {
+		t.Fatalf("skills add exited %d:\n%s%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(project, "skills-lock.json")); err != nil {
+		t.Fatalf("expected skills add to write skills-lock.json: %v", err)
+	}
+
+	after, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("knowledge-lock.json changed after a skills operation:\nbefore: %s\nafter: %s", before, after)
 	}
 }
 

--- a/tests/knowledge_test.go
+++ b/tests/knowledge_test.go
@@ -304,6 +304,92 @@ func TestKnowledgeLockSurvivesSkillsOperations(t *testing.T) {
 	}
 }
 
+func TestKnowledgeInstallRestoresFromLock(t *testing.T) {
+	project := t.TempDir()
+	src := filepath.Join(project, "src-bundle")
+	writeSourceBundle(t, src)
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	if _, stderr, code := runMdmInDir(t, project, env, "knowledge", "add", "./src-bundle", "-y"); code != 0 {
+		t.Fatalf("knowledge add exited %d: %s", code, stderr)
+	}
+	if err := os.RemoveAll(filepath.Join(project, "knowledge")); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runMdmInDir(t, project, env, "knowledge", "install")
+	if code != 0 {
+		t.Fatalf("knowledge install exited %d:\n%s%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(project, "knowledge", "src-bundle", "index.md")); err != nil {
+		t.Errorf("expected bundle to be restored: %v", err)
+	}
+}
+
+func TestKnowledgeUpdateRefetchesSource(t *testing.T) {
+	project := t.TempDir()
+	src := filepath.Join(project, "src-bundle")
+	writeSourceBundle(t, src)
+	env := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	if _, stderr, code := runMdmInDir(t, project, env, "knowledge", "add", "./src-bundle", "-y"); code != 0 {
+		t.Fatalf("knowledge add exited %d: %s", code, stderr)
+	}
+
+	// Change the source, then update: the installed copy must follow.
+	updated := "---\ntype: Concept\ntitle: Thing\n---\n\nAn updated thing.\n"
+	if err := os.WriteFile(filepath.Join(src, "concepts", "thing.md"), []byte(updated), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runMdmInDir(t, project, env, "knowledge", "update")
+	if code != 0 {
+		t.Fatalf("knowledge update exited %d:\n%s%s", code, stdout, stderr)
+	}
+	installed, err := os.ReadFile(filepath.Join(project, "knowledge", "src-bundle", "concepts", "thing.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(installed), "An updated thing") {
+		t.Errorf("expected update to re-fetch the source, got: %s", installed)
+	}
+}
+
+func TestDoctorKnowledgeSectionGated(t *testing.T) {
+	project := t.TempDir()
+	src := filepath.Join(project, "src-bundle")
+	writeSourceBundle(t, src)
+	envOn := freshEnv(t, "MDM_EXPERIMENTAL=knowledge")
+
+	if _, stderr, code := runMdmInDir(t, project, envOn, "knowledge", "add", "./src-bundle", "-y"); code != 0 {
+		t.Fatalf("knowledge add exited %d: %s", code, stderr)
+	}
+	// Break the install so doctor has something to report.
+	if err := os.RemoveAll(filepath.Join(project, "knowledge", "src-bundle")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Gate on: doctor reports the missing bundle.
+	stdout, _, code := runMdmInDir(t, project, envOn, "doctor", "-p")
+	if code != 0 {
+		t.Fatalf("doctor exited %d", code)
+	}
+	if !strings.Contains(stdout, "Knowledge bundles:") || !strings.Contains(stdout, "not found") {
+		t.Errorf("expected knowledge section with missing-bundle error, got:\n%s", stdout)
+	}
+
+	// Gate off: same project, no knowledge section — stable doctor output is
+	// unaffected by experimental state on disk.
+	envOff := freshEnv(t)
+	stdout, _, code = runMdmInDir(t, project, envOff, "doctor", "-p")
+	if code != 0 {
+		t.Fatalf("doctor exited %d", code)
+	}
+	if strings.Contains(stdout, "Knowledge bundles:") {
+		t.Errorf("doctor must not mention knowledge while the gate is off, got:\n%s", stdout)
+	}
+}
+
 func TestExperimentalList(t *testing.T) {
 	dir := t.TempDir()
 	stdout, _, code := runMdmInDir(t, dir, freshEnv(t), "experimental", "list")

--- a/tests/testdata/hidden-knowledge/index.md
+++ b/tests/testdata/hidden-knowledge/index.md
@@ -1,0 +1,10 @@
+---
+title: Hidden character fixture bundle
+description: Intentionally unsafe test data used to verify the install scan.
+---
+
+# Hidden character fixture
+
+The next line contains a zero-width space between "hidden" and "payload".
+
+hidden​payload


### PR DESCRIPTION
## Experimental OKF knowledge support (`mdm knowledge`)

### What

Adds an experimental command group for managing [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) bundles — directories of markdown documents with YAML frontmatter that give AI agents durable reference context (the "LLM-wiki" pattern Google standardized in June).

Everything ships behind a new named experimental gate and is invisible until opted in:

```
mdm experimental                # new, always visible
├── list / enable / disable     # persisted opt-ins; MDM_EXPERIMENTAL env var also works

mdm knowledge                   # hidden + refuses until the gate is on
├── add <source>                # install a bundle from GitHub/GitLab/URL/local into ./knowledge/
├── list / remove               # manage installed bundles
├── update [bundles...]         # re-fetch from recorded source+ref
├── validate [path]             # OKF conformance + link integrity (--json for CI)
├── init [name]                 # scaffold a minimal conformant bundle
└── install                     # restore everything from knowledge-lock.json (CI/onboarding)
```

Full design rationale, honest value assessment, and graduation/exit criteria are in `docs/specs/knowledge.md`; the gate mechanics are documented in `docs/experimental.md`.

### Why

- OKF bundles are the same artifact class mdm already manages for skills — fetch markdown from a repo, scan it, place it, pin it, audit it — so ~70% of this reuses existing plumbing (`source/`, `git/`, `lock/`, `security/`).
- The **hidden-character/prompt-smuggling scan is mandatory on install**. Knowledge documents are designed to be fed into agent context (and written by agents), which makes them a prime injection vector; no other OKF tooling checks this today.
- The spec is v0.1 and three weeks old, so the experimental gate is the point: we can evolve alongside the standard (or delete the feature) without semver obligations. Every lock entry records the `specVersion` it targeted.

### Key design decisions

- **Separate `knowledge-lock.json`**, not new keys in `skills-lock.json`: the skill locks are unmarshaled into fixed structs and rewritten wholesale, so an older binary touching skills would silently drop unknown keys. A separate file gives the experiment zero blast radius (regression-tested).
- **Zero footprint when disabled**: `knowledge` is absent from help/completion, invoking it exits non-zero with the enable hint, and `mdm doctor` output is unchanged. When enabled, every invocation prints a one-line experimental banner and doctor gains a knowledge section (missing dirs, content-hash drift, conformance errors).
- **`add` validates but doesn't block** on conformance errors — an imperfect bundle is still useful; `validate` is the strict path. Installs always clone (no GitHub blob fast-path yet).

### How to test

```bash
make build

# Gate off (default): invisible and inert
./mdm --help | grep knowledge        # no output
./mdm knowledge                      # refuses with enable instructions, exit 1

# Enable and walk the lifecycle
./mdm experimental enable knowledge  # or: export MDM_EXPERIMENTAL=knowledge
./mdm knowledge init sales           # scaffold a bundle
./mdm knowledge validate sales       # ✓ 2 document(s) valid
./mdm knowledge add ./sales -y       # installs to ./knowledge/sales, writes knowledge-lock.json
./mdm knowledge list

# Drift detection + restore
echo tampered >> knowledge/sales/index.md
./mdm doctor -p                      # warns: content hash mismatch
./mdm knowledge update sales         # re-fetches from the recorded source
rm -rf knowledge && ./mdm knowledge install   # restores from the lock

# Security gate: a bundle containing hidden Unicode blocks the install
./mdm knowledge add tests/testdata/hidden-knowledge -y   # exit 1, findings printed

# Validation failure modes
./mdm knowledge validate internal/okf/testdata/broken-link --json   # exit 1, machine-readable