### PR TITLE
ci: align codeql-action init and analyze to v4.37.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: go
           queries: security-extended
@@ -33,6 +33,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:go"


### PR DESCRIPTION
Dependabot opened separate PRs (#103, #105) bumping only one
codeql-action step each, producing a version mismatch between
init and analyze. CodeQL requires all steps in an analysis job
to run the same version, so both PRs failed the Analyze (Go) job
with a configuration-error. Bump both init and analyze to v4.37.0
together to resolve the mismatch.